### PR TITLE
Fix fork CI: remove cmuxd refs, fix hashFiles glob

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ghostty/zig-out/lib/GhosttyKit.xcframework
-          key: ghosttykit-${{ hashFiles('ghostty/.git/HEAD', 'ghostty/.git/refs/heads/**') }}
+          key: ghosttykit-${{ hashFiles('ghostty/**/*.zig', 'ghostty/build.zig.zon') }}
 
       - name: Build GhosttyKit
         if: steps.cache-ghosttykit.outputs.cache-hit != 'true'
@@ -58,24 +58,6 @@ jobs:
             ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Fork \
             PRODUCT_NAME="cmux LAB" \
             build
-
-  build-linux-daemon:
-    name: Build Linux daemon
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-
-      - name: Build cmuxd (x86_64)
-        run: |
-          cd cmuxd
-          zig build -Doptimize=ReleaseFast
 
   nix-check:
     name: Nix flake check

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -57,106 +57,9 @@ jobs:
           name: cmux-lab-macos
           path: cmux-lab-macos.dmg
 
-  build-linux-daemon:
-    name: Build Linux daemon (cmuxd)
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-linux
-            arch: amd64
-          - target: aarch64-linux
-            arch: arm64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-
-      - name: Build cmuxd
-        run: |
-          cd cmuxd
-          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}-gnu
-          cp zig-out/bin/cmuxd ../cmuxd-${{ matrix.arch }}
-
-      - name: Create DEB package
-        run: |
-          ARCH=${{ matrix.arch }}
-          VERSION=${GITHUB_REF_NAME#lab-v}
-          [ -z "$VERSION" ] && VERSION="0.0.0"
-          PKG_DIR="cmux-lab_${VERSION}_${ARCH}"
-          mkdir -p "${PKG_DIR}/DEBIAN"
-          mkdir -p "${PKG_DIR}/usr/bin"
-          mkdir -p "${PKG_DIR}/usr/share/doc/cmux-lab"
-
-          cp cmuxd-${ARCH} "${PKG_DIR}/usr/bin/cmuxd-lab"
-          chmod 755 "${PKG_DIR}/usr/bin/cmuxd-lab"
-
-          cat > "${PKG_DIR}/DEBIAN/control" <<CTRL
-          Package: cmux-lab
-          Version: ${VERSION}
-          Architecture: ${ARCH}
-          Maintainer: Jess Sullivan <jess@jesssullivan.dev>
-          Description: cmux LAB remote daemon with FIDO2/WebAuthn support
-           Terminal multiplexer remote daemon for enterprise auth testing.
-          Homepage: https://github.com/Jesssullivan/cmux
-          CTRL
-          # Remove leading spaces from heredoc
-          sed -i 's/^          //' "${PKG_DIR}/DEBIAN/control"
-
-          dpkg-deb --build "${PKG_DIR}"
-          mv "${PKG_DIR}.deb" "cmux-lab_${VERSION}_${ARCH}.deb"
-
-      - name: Create RPM package
-        if: matrix.arch == 'amd64'
-        run: |
-          sudo apt-get install -y rpm
-          VERSION=${GITHUB_REF_NAME#lab-v}
-          [ -z "$VERSION" ] && VERSION="0.0.0"
-
-          mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-          cp cmuxd-amd64 rpmbuild/SOURCES/cmuxd-lab
-
-          cat > rpmbuild/SPECS/cmux-lab.spec <<'SPEC'
-          Name:           cmux-lab
-          Version:        %{version}
-          Release:        1%{?dist}
-          Summary:        cmux LAB remote daemon with FIDO2/WebAuthn support
-          License:        MIT
-          URL:            https://github.com/Jesssullivan/cmux
-
-          %description
-          Terminal multiplexer remote daemon for enterprise auth testing.
-
-          %install
-          mkdir -p %{buildroot}/usr/bin
-          cp %{_sourcedir}/cmuxd-lab %{buildroot}/usr/bin/cmuxd-lab
-          chmod 755 %{buildroot}/usr/bin/cmuxd-lab
-
-          %files
-          /usr/bin/cmuxd-lab
-          SPEC
-          sed -i 's/^          //' rpmbuild/SPECS/cmux-lab.spec
-          sed -i "s/%{version}/${VERSION}/" rpmbuild/SPECS/cmux-lab.spec
-
-          rpmbuild --define "_topdir $(pwd)/rpmbuild" -bb rpmbuild/SPECS/cmux-lab.spec || true
-
-      - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: cmux-lab-linux-${{ matrix.arch }}
-          path: |
-            cmuxd-${{ matrix.arch }}
-            cmux-lab_*.deb
-            rpmbuild/RPMS/**/*.rpm
-
   release:
     name: Create GitHub Release
-    needs: [build-macos, build-linux-daemon]
+    needs: [build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -171,12 +74,12 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           [ -z "$TAG" ] && TAG="${{ github.event.inputs.tag }}"
 
-          # Collect all release assets
           ASSETS=()
-          for f in cmux-lab-macos/*.dmg cmux-lab-linux-*/*.deb cmux-lab-linux-*/cmuxd-* cmux-lab-linux-*/rpmbuild/RPMS/**/*.rpm; do
+          for f in cmux-lab-macos/*.dmg; do
             [ -f "$f" ] && ASSETS+=("$f")
           done
 
+          gh release upload "$TAG" "${ASSETS[@]}" --clobber 2>/dev/null || \
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --title "cmux LAB $TAG" \
@@ -184,9 +87,6 @@ jobs:
 
           ## Assets
           - **cmux-lab-macos.dmg** — macOS .app bundle (trans-themed LAB branding)
-          - **cmuxd-amd64** / **cmuxd-arm64** — Linux remote daemon binaries
-          - **.deb** — Debian/Ubuntu packages
-          - **.rpm** — RHEL/Fedora packages (amd64)
 
           ## Nix
           \`\`\`bash


### PR DESCRIPTION
Fixes fork-ci.yml failures: cmuxd doesn't exist in this repo, and hashFiles pattern was invalid for .git paths. Simplifies fork-release.yml to macOS-only (no Linux daemon).