### PR TITLE
Fix fork CI: use macos-15 runner for SDK compatibility

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-macos:
     name: Build macOS (LAB)
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-macos:
     name: Build macOS .app
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GhosttyKit requires macOS 15 SDK (kCVPixelFormatType_30RGB_r210). Upstream CI uses macos-15 runners.