### PR TITLE
Fix fork CI: native xcframework target, skip macOS app

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -35,7 +35,7 @@ jobs:
         if: steps.cache-ghosttykit.outputs.cache-hit != 'true'
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
 
       - name: Build cmux LAB (Debug)
         run: |

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build GhosttyKit
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
 
       - name: Build cmux LAB (Release)
         run: |


### PR DESCRIPTION
Universal xcframework build fails on GitHub-hosted runners (DockTilePlugin x86_64 Swift compile). Use native target + skip macos app (matching upstream's -Demit-macos-app=false).