### PR TITLE
Fix fork CI: symlink GhosttyKit.xcframework to repo root

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -37,6 +37,9 @@ jobs:
           cd ghostty
           zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
 
+      - name: Link GhosttyKit xcframework
+        run: ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
+
       - name: Build cmux LAB (Debug)
         run: |
           xcodebuild -project GhosttyTabs.xcodeproj \

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -33,6 +33,9 @@ jobs:
           cd ghostty
           zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
 
+      - name: Link GhosttyKit xcframework
+        run: ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
+
       - name: Build cmux LAB (Release)
         run: |
           xcodebuild -project GhosttyTabs.xcodeproj \


### PR DESCRIPTION
Xcode project expects GhosttyKit.xcframework at repo root, but zig builds to ghostty/zig-out/lib/. Add symlink step.