### PR TITLE
Fix fork release: dynamic xcframework discovery + build diagnostics

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -32,11 +32,21 @@ jobs:
         run: |
           cd ghostty
           zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
+          echo "=== zig-out contents ==="
+          find zig-out -name "*.xcframework" -o -name "*.a" 2>/dev/null | head -20
+          ls -laR zig-out/lib/ 2>/dev/null | head -30
 
       - name: Link GhosttyKit xcframework
         run: |
-          ls -la ghostty/zig-out/lib/GhosttyKit.xcframework/ || echo "xcframework NOT found at expected path"
-          ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
+          # Find the xcframework wherever zig put it
+          XCFW=$(find ghostty/zig-out -name "GhosttyKit.xcframework" -type d | head -1)
+          if [ -z "$XCFW" ]; then
+            echo "ERROR: GhosttyKit.xcframework not found in ghostty/zig-out"
+            find ghostty/zig-out -type d | head -30
+            exit 1
+          fi
+          echo "Found xcframework at: $XCFW"
+          ln -sfn "$XCFW" GhosttyKit.xcframework
           ls -la GhosttyKit.xcframework/
 
       - name: Build cmux LAB (Release)


### PR DESCRIPTION
Find GhosttyKit.xcframework dynamically after zig build. Add diagnostics to understand zig output layout.