### PR TITLE
Fix fork CI: disable zig cache to ensure xcframework output

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -23,25 +23,17 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
-
-      - name: Cache GhosttyKit
-        id: cache-ghosttykit
-        uses: actions/cache@v4
-        with:
-          path: ghostty/zig-out/lib/GhosttyKit.xcframework
-          key: ghosttykit-native-${{ hashFiles('ghostty/build.zig', 'ghostty/build.zig.zon') }}
+          use-cache: false
 
       - name: Build GhosttyKit
-        if: steps.cache-ghosttykit.outputs.cache-hit != 'true'
         run: |
           cd ghostty
+          rm -rf zig-out
           zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
+          ls -la zig-out/lib/GhosttyKit.xcframework/
 
       - name: Link GhosttyKit xcframework
-        run: |
-          ls -la ghostty/zig-out/lib/GhosttyKit.xcframework/ || echo "xcframework NOT found at expected path"
-          ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
-          ls -la GhosttyKit.xcframework/
+        run: ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
 
       - name: Build cmux LAB (Debug)
         run: |

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -27,27 +27,17 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          use-cache: false
 
       - name: Build GhosttyKit
         run: |
           cd ghostty
+          rm -rf zig-out
           zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
-          echo "=== zig-out contents ==="
-          find zig-out -name "*.xcframework" -o -name "*.a" 2>/dev/null | head -20
-          ls -laR zig-out/lib/ 2>/dev/null | head -30
+          ls -la zig-out/lib/GhosttyKit.xcframework/
 
       - name: Link GhosttyKit xcframework
-        run: |
-          # Find the xcframework wherever zig put it
-          XCFW=$(find ghostty/zig-out -name "GhosttyKit.xcframework" -type d | head -1)
-          if [ -z "$XCFW" ]; then
-            echo "ERROR: GhosttyKit.xcframework not found in ghostty/zig-out"
-            find ghostty/zig-out -type d | head -30
-            exit 1
-          fi
-          echo "Found xcframework at: $XCFW"
-          ln -sfn "$XCFW" GhosttyKit.xcframework
-          ls -la GhosttyKit.xcframework/
+        run: ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
 
       - name: Build cmux LAB (Release)
         run: |


### PR DESCRIPTION
setup-zig cache causes zig to skip producing output artifacts. Disable cache, clean zig-out before build.