### PR TITLE
Fix fork CI: use universal xcframework target

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cd ghostty
           rm -rf zig-out
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
           ls -la zig-out/lib/GhosttyKit.xcframework/
 
       - name: Link GhosttyKit xcframework

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           cd ghostty
           rm -rf zig-out
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
           ls -la zig-out/lib/GhosttyKit.xcframework/
 
       - name: Link GhosttyKit xcframework


### PR DESCRIPTION
native target doesn't produce xcframework output. Switch back to universal with use-cache: false and rm -rf zig-out to avoid stale state. The earlier DockTilePlugin failure was from stale zig cache, not from universal target itself.