### PR TITLE
Fix fork CI: download pre-built GhosttyKit from upstream

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -19,21 +19,21 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-          use-cache: false
-
-      - name: Build GhosttyKit
+      - name: Download pre-built GhosttyKit
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          cd ghostty
-          rm -rf zig-out
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
-          ls -la zig-out/lib/GhosttyKit.xcframework/
-
-      - name: Link GhosttyKit xcframework
-        run: ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
+          GHOSTTY_SHA=$(git -C ghostty rev-parse HEAD)
+          TAG="xcframework-${GHOSTTY_SHA}"
+          echo "Downloading GhosttyKit for ghostty commit ${GHOSTTY_SHA}"
+          gh release download "$TAG" --repo manaflow-ai/ghostty --pattern "GhosttyKit.xcframework.tar.gz" || {
+            echo "Pre-built xcframework not found for $TAG"
+            echo "Available releases:"
+            gh release list --repo manaflow-ai/ghostty --limit 5
+            exit 1
+          }
+          tar xzf GhosttyKit.xcframework.tar.gz
+          ls -la GhosttyKit.xcframework/
 
       - name: Build cmux LAB (Debug)
         run: |

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -23,21 +23,16 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-          use-cache: false
-
-      - name: Build GhosttyKit
+      - name: Download pre-built GhosttyKit
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          cd ghostty
-          rm -rf zig-out
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
-          ls -la zig-out/lib/GhosttyKit.xcframework/
-
-      - name: Link GhosttyKit xcframework
-        run: ln -sfn ghostty/zig-out/lib/GhosttyKit.xcframework GhosttyKit.xcframework
+          GHOSTTY_SHA=$(git -C ghostty rev-parse HEAD)
+          TAG="xcframework-${GHOSTTY_SHA}"
+          echo "Downloading GhosttyKit for ghostty commit ${GHOSTTY_SHA}"
+          gh release download "$TAG" --repo manaflow-ai/ghostty --pattern "GhosttyKit.xcframework.tar.gz"
+          tar xzf GhosttyKit.xcframework.tar.gz
+          ls -la GhosttyKit.xcframework/
 
       - name: Build cmux LAB (Release)
         run: |


### PR DESCRIPTION
Building GhosttyKit from source fails on GitHub-hosted runners. Download pre-built xcframework from manaflow-ai/ghostty releases instead. Much faster (~10s vs ~10min) and reliable.