### PR TITLE
Fix fork CI: cmux-LAB (no space) avoids xcodebuild bundle conflicts

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -43,7 +43,7 @@ jobs:
             -destination 'platform=macOS' \
             -derivedDataPath /tmp/cmux-fork-ci \
             ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Fork \
-            PRODUCT_NAME="cmux LAB" \
+            PRODUCT_NAME=cmux-LAB \
             build
 
       - name: Build cmux LAB (Release)
@@ -54,7 +54,7 @@ jobs:
             -destination 'platform=macOS' \
             -derivedDataPath build \
             ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Fork \
-            PRODUCT_NAME="cmux LAB" \
+            PRODUCT_NAME=cmux-LAB \
             build
 
   nix-check:

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -42,15 +42,15 @@ jobs:
             -destination 'platform=macOS' \
             -derivedDataPath build \
             ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Fork \
-            PRODUCT_NAME="cmux LAB" \
+            PRODUCT_NAME=cmux-LAB \
             PRODUCT_BUNDLE_IDENTIFIER=com.cmuxterm.app.lab \
             build
 
       - name: Package DMG
         run: |
-          APP_PATH="build/Build/Products/Release/cmux LAB.app"
+          APP_PATH="build/Build/Products/Release/cmux-LAB.app"
           npx create-dmg@8.0.0 "$APP_PATH" . --overwrite || true
-          mv *.dmg cmux-lab-macos.dmg 2>/dev/null || mv "cmux LAB"*.dmg cmux-lab-macos.dmg
+          mv *.dmg cmux-lab-macos.dmg 2>/dev/null || mv cmux-LAB*.dmg cmux-lab-macos.dmg
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Space in PRODUCT_NAME causes 'Multiple commands produce' errors.