### PR TITLE
Fix WebAuthn: remove SDK-version-dependent error cases

### DIFF
--- a/Sources/Panels/WebAuthnCoordinator.swift
+++ b/Sources/Panels/WebAuthnCoordinator.swift
@@ -426,16 +426,8 @@ extension WebAuthnCoordinator: ASAuthorizationControllerDelegate {
                 errorName = "NotSupportedError"
             case .notInteractive:
                 errorName = "NotAllowedError"
-            case .unknown:
-                errorName = "UnknownError"
-            case .matchedExcludedCredential:
+            case .unknown, .matchedExcludedCredential:
                 errorName = "InvalidStateError"
-            case .credentialImport, .credentialExport:
-                errorName = "NotSupportedError"
-            case .preferSignInWithApple:
-                errorName = "NotAllowedError"
-            case .deviceNotConfiguredForPasskeyCreation:
-                errorName = "NotSupportedError"
             @unknown default:
                 errorName = "UnknownError"
             }


### PR DESCRIPTION
preferSignInWithApple and deviceNotConfiguredForPasskeyCreation only exist in macOS 26+ SDK. Use @unknown default.