### PR TITLE
Fix fork CI: install zig for CLI helper build

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+          use-cache: false
+
       - name: Download pre-built GhosttyKit
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+          use-cache: false
+
       - name: Download pre-built GhosttyKit
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Pre-built xcframework skips the zig GhosttyKit build, but zig is still needed for the Ghostty CLI helper binary during xcodebuild.