### PR TITLE
Fix CAPTCHA failures: stop injecting scripts into cross-origin iframes

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2462,20 +2462,24 @@ final class BrowserPanel: Panel, ObservableObject {
         // Enable JavaScript
         config.defaultWebpagePreferences.allowsContentJavaScript = true
         // Keep browser console/error/dialog telemetry active from document start on every navigation.
+        // Main frame only — injecting into cross-origin iframes (forMainFrameOnly: false)
+        // causes CAPTCHA providers (reCAPTCHA, hCaptcha, Cloudflare Turnstile) to detect
+        // the overridden console.* methods and __cmux* globals as environment tampering.
         config.userContentController.addUserScript(
             WKUserScript(
                 source: Self.telemetryHookBootstrapScriptSource,
                 injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
+                forMainFrameOnly: true
             )
         )
         // Track the last editable focused element continuously so omnibar exit can
         // restore page input focus even if capture runs after first-responder handoff.
+        // Main frame only — same CAPTCHA interference concern as telemetry hooks.
         config.userContentController.addUserScript(
             WKUserScript(
                 source: Self.addressBarFocusTrackingBootstrapScript,
                 injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
+                forMainFrameOnly: true
             )
         )
 

--- a/Sources/Panels/WebAuthnBridgeJavaScript.swift
+++ b/Sources/Panels/WebAuthnBridgeJavaScript.swift
@@ -11,7 +11,7 @@ enum WebAuthnBridgeJavaScript {
     /// Message handler name shared between this JS and `WebAuthnCoordinator`.
     static let messageHandlerName = "cmuxWebAuthn"
 
-    /// Bootstrap script source. Inject as a `WKUserScript` at `.atDocumentStart`, `forMainFrameOnly: false`.
+    /// Bootstrap script source. Inject as a `WKUserScript` at `.atDocumentStart`, `forMainFrameOnly: true`.
     static let bootstrapScriptSource = """
     (() => {
       if (window.__cmuxWebAuthnBridgeInstalled) return true;

--- a/Sources/Panels/WebAuthnCoordinator.swift
+++ b/Sources/Panels/WebAuthnCoordinator.swift
@@ -32,11 +32,14 @@ final class WebAuthnCoordinator: NSObject {
     /// user content controller. Call once during web view configuration, before
     /// the first navigation.
     func install(on controller: WKUserContentController) {
+        // Main frame only — WebAuthn is initiated by the top-level page, and injecting
+        // navigator.credentials overrides into cross-origin iframes triggers CAPTCHA
+        // providers' environment tampering detection.
         controller.addUserScript(
             WKUserScript(
                 source: WebAuthnBridgeJavaScript.bootstrapScriptSource,
                 injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
+                forMainFrameOnly: true
             )
         )
         controller.addScriptMessageHandler(


### PR DESCRIPTION
forMainFrameOnly: false caused telemetry/focus/WebAuthn scripts to run inside CAPTCHA iframes (Cloudflare Turnstile, reCAPTCHA, hCaptcha), where providers detect the overridden console methods and __cmux globals as tampering. Blocks sign-in on GitLab and other sites using CAPTCHAs.