### PR TITLE
Add Apple Developer signing + notarization to fork releases

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build-macos:
-    name: Build macOS .app
+    name: Build, sign, and package macOS .app
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -51,11 +51,77 @@ jobs:
             PRODUCT_BUNDLE_IDENTIFIER=com.cmuxterm.app.lab \
             build
 
-      - name: Package DMG
+      - name: Import signing cert
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > /tmp/cert.p12
+          security delete-keychain build.keychain >/dev/null 2>&1 || true
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security import /tmp/cert.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          security list-keychains -d user -s build.keychain
+          rm -f /tmp/cert.p12
+
+      - name: Codesign app
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
           APP_PATH="build/Build/Products/Release/cmux.app"
-          npx create-dmg@8.0.0 "$APP_PATH" . --overwrite || true
-          # Rename whatever DMG create-dmg produced
+          ENTITLEMENTS="cmux.entitlements"
+          EMBEDDED_ENTITLEMENTS="cmux.embedded.entitlements"
+          CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
+          HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+          # Deep-sign the bundle first, then narrow embedded executables back down.
+          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
+          if [ -f "$CLI_PATH" ]; then
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
+          fi
+          if [ -f "$HELPER_PATH" ]; then
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
+          fi
+          /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          echo "Codesign verified"
+          # Confirm team ID is embedded
+          codesign -d --verbose=2 "$APP_PATH" 2>&1 | grep "TeamIdentifier"
+
+      - name: Notarize app
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          APP_PATH="build/Build/Products/Release/cmux.app"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" cmux-notary.zip
+          SUBMIT_JSON="$(xcrun notarytool submit cmux-notary.zip \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --wait --output-format json)"
+          SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$SUBMIT_JSON")"
+          STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$SUBMIT_JSON")"
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "Notarization failed: $STATUS" >&2
+            xcrun notarytool log "$SUBMIT_ID" \
+              --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+            exit 1
+          fi
+          xcrun stapler staple "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          rm -f cmux-notary.zip
+          echo "Notarization complete"
+
+      - name: Package DMG
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          APP_PATH="build/Build/Products/Release/cmux.app"
+          npx create-dmg@8.0.0 --identity="$APPLE_SIGNING_IDENTITY" "$APP_PATH" . --overwrite || true
           for f in *.dmg; do
             [ -f "$f" ] && mv "$f" cmux-lab-macos.dmg && break
           done
@@ -67,6 +133,10 @@ jobs:
         with:
           name: cmux-lab-macos
           path: cmux-lab-macos.dmg
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain build.keychain >/dev/null 2>&1 || true
 
   release:
     name: Create GitHub Release
@@ -96,10 +166,10 @@ jobs:
             exit 1
           fi
 
-          NOTES="Fork release with FIDO2/WebAuthn enterprise auth support.
+          NOTES="Signed and notarized fork release with FIDO2/WebAuthn enterprise auth support.
 
           ## Assets
-          - **cmux-lab-macos.dmg** — macOS .app bundle (trans-themed LAB branding)
+          - **cmux-lab-macos.dmg** — signed macOS .app (trans-themed LAB branding, Developer ID)
 
           ## Nix
           \`\`\`bash


### PR DESCRIPTION
Enables WebAuthn by giving the app a real team ID. Imports Developer ID cert, codesigns with entitlements, notarizes with Apple.