### PR TITLE
Remove restricted entitlement that crashes macOS 26 on launch

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -14,7 +14,5 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
-	<key>com.apple.developer.web-browser.public-key-credential</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Same issue as upstream #1739. Our JS bridge doesn't need it — team ID alone is sufficient.