### PR TITLE
Add application-identifier entitlement for WebAuthn

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.application-identifier</key>
+	<string>QP994XQKNH.com.cmuxterm.app.lab</string>
 </dict>
 </plist>


### PR DESCRIPTION
ASAuthorizationController needs com.apple.application-identifier (TEAMID.BUNDLEID). Team ID in code signature alone is insufficient.