### PR TITLE
Fix libctap2: native arch build, add ARCHS=arm64 to xcodebuild

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -54,6 +54,7 @@ jobs:
             -scheme cmux \
             -configuration Debug \
             -destination 'platform=macOS' \
+            ARCHS=arm64 \
             -derivedDataPath /tmp/cmux-fork-ci \
             ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Fork \
             build
@@ -64,6 +65,7 @@ jobs:
             -scheme cmux \
             -configuration Release \
             -destination 'platform=macOS' \
+            ARCHS=arm64 \
             -derivedDataPath build \
             ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Fork \
             build

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -54,6 +54,7 @@ jobs:
             -configuration Release \
             -destination 'platform=macOS' \
             -derivedDataPath build \
+            ARCHS=arm64 \
             ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Fork \
             PRODUCT_BUNDLE_IDENTIFIER=com.cmuxterm.app.lab \
             build


### PR DESCRIPTION
Cross-compilation fails because Zig can't find macOS SDK headers for @cImport. Build native arch and constrain xcodebuild to arm64.