### PR TITLE
Add USB device entitlement for FIDO2 HID

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -14,6 +14,8 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
 	<key>com.apple.application-identifier</key>
 	<string>QP994XQKNH.com.cmuxterm.app.lab</string>
 </dict>


### PR DESCRIPTION
kIOReturnNotPermitted under hardened runtime. Adds com.apple.security.device.usb.