### PR TITLE
Add zig-ctap2 test execution to fork CI

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -48,6 +48,12 @@ jobs:
           cp zig-out/lib/libctap2.a ../../
           cp include/ctap2.h ../../
 
+      - name: Run zig-ctap2 tests
+        run: |
+          cd vendor/ctap2
+          zig build test
+          zig build test-pbt
+
       - name: Build cmux LAB (Debug)
         run: |
           xcodebuild -project GhosttyTabs.xcodeproj \


### PR DESCRIPTION
## Summary
- Add `zig build test` and `zig build test-pbt` step to fork-ci.yml
- Runs after libctap2 build, before cmux Debug build
- Surfaces ctap2 unit and property-based test failures early in CI

## Test plan
- [ ] Fork CI passes with the new test step on macOS-15