### PR TITLE
Remove unused JIT and unsigned-memory entitlements

### DIFF
--- a/cmux.embedded.entitlements
+++ b/cmux.embedded.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
 </dict>
 </plist>

--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -4,10 +4,6 @@
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 	<key>com.apple.security.device.usb</key>


### PR DESCRIPTION
## Summary

Removes 2 unnecessary code-signing entitlements from both `cmux.entitlements` and `cmux.embedded.entitlements`:

- **`cs.allow-jit`**: No JIT code in cmux. WKWebView's JavaScript runs in a separate WebContent process with its own entitlements — the host app doesn't need this.
- **`cs.allow-unsigned-executable-memory`**: Redundant (subset of allow-jit) and no runtime code generation exists.

Keeps `cs.disable-library-validation` (documented perf fix for dylib load lag).

**Before:** 8 entitlements (main) + 2 (embedded)
**After:** 4 entitlements (main) + 1 (embedded)

This reduces the security surface for fork builds and moves us closer to minimal entitlements for Linux porting.

## Test plan
- [ ] Fork CI builds clean
- [ ] App launches without hardened runtime errors
- [ ] WebAuthn still works (device.usb preserved)
- [ ] AppleScript still works (apple-events preserved)