### PR TITLE
Restore camera and audio-input entitlements

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 	<key>com.apple.security.device.usb</key>


### PR DESCRIPTION
## Summary

Restores `device.camera` and `device.audio-input` entitlements that were incorrectly removed. Upstream commits added browser media capture support (Google Meet, Zoom, voice transcription) that requires these entitlements.

**Entitlements: 4 → 6** (correctly: 8 original → 6 after removing only JIT/unsigned-memory)

## Test plan
- [ ] Google Meet camera prompt works
- [ ] Microphone access prompt works on voice sites