### PR TITLE
fix(ci): use workflow_dispatch input tag for releases

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -54,8 +54,11 @@ jobs:
 
       - name: Build remote daemon binaries
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          [ -z "$TAG" ] && TAG="${{ github.event.inputs.tag }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
           VERSION="${TAG#lab-v}"
           ./scripts/build_remote_daemon_release_assets.sh \
             --version "$VERSION" \
@@ -186,8 +189,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          [ -z "$TAG" ] && TAG="${{ github.event.inputs.tag }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
 
           ASSETS=()
           for f in cmux-lab-macos/*.dmg; do


### PR DESCRIPTION
## Summary
- On `workflow_dispatch`, `GITHUB_REF_NAME` resolves to the branch name (`main`), not the tag input
- This caused lab-v0.73.0 release assets to land on the `main` release instead
- Fix: check `github.event_name` to pick the correct tag source

## Test plan
- [ ] Merge, then re-trigger `workflow_dispatch` with `tag=lab-v0.73.0`
- [ ] Verify release is created with correct tag name