### PR TITLE
Add self-hosted GPU runner for cmux-linux smoke tests

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -29,6 +29,10 @@ jobs:
   gpu-smoke:
     name: GPU smoke test (honey)
     runs-on: [self-hosted, linux, gpu, cmux-test]
+    # Require approval via GitHub Environment protection rules.
+    # Create "gpu-tests" environment at Settings > Environments with
+    # required reviewers before this will run automatically.
+    environment: gpu-tests
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # Setup a self-hosted GitHub Actions runner for cmux-linux GPU testing.
 #
+# SECURITY:
+#   - Creates a dedicated unprivileged 'github-runner' user
+#   - Runner only accessible via push triggers (no fork PR execution)
+#   - GPU workflow requires 'gpu-tests' environment approval in GitHub
+#   - No secrets stored on disk; use GitHub encrypted secrets only
+#   - Runner registered with --replace to prevent stale registrations
+#
 # Prerequisites:
 #   - Linux x86_64 with AMD GPU (RDNA 2+ for OpenGL 4.6)
-#   - User in 'render' and 'video' groups for GPU access
+#   - sudo access to create user and install packages
 #   - Network access to GitHub API
 #
 # Usage:
@@ -11,6 +18,9 @@
 #
 # The token needs 'repo' scope. Generate at:
 #   https://github.com/Jesssullivan/cmux/settings/actions/runners/new
+#
+# After setup, create the 'gpu-tests' environment in GitHub repo settings
+# (Settings > Environments > New) with required reviewers enabled.
 
 set -euo pipefail
 


### PR DESCRIPTION
Adds infrastructure for running cmux-linux GPU tests on honey (AMD RX 9070 XT):

- scripts/setup-runner.sh — bootstrap script to register honey as a self-hosted runner
- .github/workflows/test-gpu.yml — GPU smoke test workflow

The GPU test goes beyond the Xvfb/llvmpipe CI tests by using real OpenGL hardware,
which avoids the MESA_GL_VERSION_OVERRIDE limitations that cause crashes on CI runners.

Tests: socket ping, workspace.list, system.identify, clean shutdown, GDB backtrace on crashes.

To activate: run setup-runner.sh on honey with a GITHUB_TOKEN, then trigger the workflow.