### PR TITLE
M5b Sprint 1: WebKitGTK 6.0 browser panel integration (#86)

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -340,6 +340,7 @@ jobs:
             pkg-config \
             gtk4 \
             libadwaita \
+            webkitgtk-6.0 \
             libsecret \
             libnotify \
             wayland \

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -68,6 +68,7 @@ jobs:
           sudo apt-get install -y \
             libsecret-1-dev libnotify-dev pkg-config \
             libgtk-4-dev libadwaita-1-dev \
+            libwebkitgtk-6.0-dev \
             libfreetype-dev libharfbuzz-dev libfontconfig-dev \
             libpng-dev libonig-dev libgl-dev \
             glslang-tools spirv-cross

--- a/cmux-linux/build.zig
+++ b/cmux-linux/build.zig
@@ -21,10 +21,11 @@ pub fn build(b: *std.Build) void {
     });
 
     if (!headless) {
-        // Full GUI mode: GTK4 + libadwaita + OpenGL
+        // Full GUI mode: GTK4 + libadwaita + OpenGL + WebKitGTK
         exe.root_module.linkSystemLibrary("gtk4", .{});
         exe.root_module.linkSystemLibrary("libadwaita-1", .{});
         exe.root_module.linkSystemLibrary("gl", .{});
+        exe.root_module.linkSystemLibrary("webkitgtk-6.0", .{});
     }
 
     // libghostty: shared library built from ghostty submodule.

--- a/cmux-linux/src/browser.zig
+++ b/cmux-linux/src/browser.zig
@@ -1,0 +1,163 @@
+/// Browser panel: embeds a WebKitGTK 6.0 WebView in the split tree.
+///
+/// Handles navigation, title/URL tracking, and signal connections.
+/// Parallel to surface.zig (terminal panels) in the panel architecture.
+
+const std = @import("std");
+const c = @import("c_api.zig");
+
+const log = std.log.scoped(.browser);
+
+/// State for a single browser panel.
+pub const BrowserView = struct {
+    /// The WebKitWebView instance.
+    web_view: *c.WebKitWebView,
+    /// The WebKitSettings for this view.
+    settings: *c.WebKitSettings,
+    /// Current URL (updated on navigation).
+    current_url: ?[*:0]const u8 = null,
+    /// Current page title (updated on load).
+    current_title: ?[*:0]const u8 = null,
+    /// Whether a page is currently loading.
+    is_loading: bool = false,
+
+    /// Create a new browser view and optionally navigate to a URL.
+    pub fn create(initial_url: ?[]const u8) !*c.GtkWidget {
+        // Create settings with sane defaults
+        const settings: *c.WebKitSettings = @ptrCast(c.webkit.webkit_settings_new() orelse
+            return error.SettingsCreationFailed);
+
+        // Enable developer extras (F12 inspector)
+        c.webkit.webkit_settings_set_enable_developer_extras(settings, 1);
+        // Enable JavaScript
+        c.webkit.webkit_settings_set_enable_javascript(settings, 1);
+        // Allow autoplay (for media-heavy sites)
+        c.webkit.webkit_settings_set_media_playback_requires_user_gesture(settings, 0);
+
+        // Create the web view
+        const web_view: *c.WebKitWebView = @ptrCast(c.webkit.webkit_web_view_new() orelse
+            return error.WebViewCreationFailed);
+
+        // Apply settings
+        c.webkit.webkit_web_view_set_settings(web_view, settings);
+
+        // Make the widget expand to fill available space
+        const widget: *c.GtkWidget = @ptrCast(@alignCast(web_view));
+        c.gtk.gtk_widget_set_hexpand(widget, 1);
+        c.gtk.gtk_widget_set_vexpand(widget, 1);
+        c.gtk.gtk_widget_set_focusable(widget, 1);
+        c.gtk.gtk_widget_set_can_focus(widget, 1);
+
+        // Allocate browser state and store as widget data
+        const alloc = std.heap.c_allocator;
+        const view = try alloc.create(BrowserView);
+        view.* = .{
+            .web_view = web_view,
+            .settings = settings,
+        };
+        c.gtk.g_object_set_data(@ptrCast(@alignCast(web_view)), "cmux-browser", view);
+
+        // Connect signals
+        _ = c.gtk.g_signal_connect_data(
+            @ptrCast(@alignCast(web_view)),
+            "load-changed",
+            @ptrCast(&onLoadChanged),
+            view,
+            null,
+            0,
+        );
+
+        _ = c.gtk.g_signal_connect_data(
+            @ptrCast(@alignCast(web_view)),
+            "notify::title",
+            @ptrCast(&onTitleChanged),
+            view,
+            null,
+            0,
+        );
+
+        _ = c.gtk.g_signal_connect_data(
+            @ptrCast(@alignCast(web_view)),
+            "notify::uri",
+            @ptrCast(&onUriChanged),
+            view,
+            null,
+            0,
+        );
+
+        // Navigate to initial URL if provided
+        if (initial_url) |url| {
+            // Need null-terminated string for C API
+            const url_z = alloc.dupeZ(u8, url) catch null;
+            if (url_z) |z| {
+                c.webkit.webkit_web_view_load_uri(web_view, z.ptr);
+                alloc.free(z);
+            }
+        }
+
+        log.info("Browser panel created", .{});
+        return widget;
+    }
+
+    /// Navigate to a URL.
+    pub fn navigate(self: *BrowserView, url: [*:0]const u8) void {
+        c.webkit.webkit_web_view_load_uri(self.web_view, url);
+    }
+
+    /// Go back in navigation history.
+    pub fn goBack(self: *BrowserView) void {
+        c.webkit.webkit_web_view_go_back(self.web_view);
+    }
+
+    /// Go forward in navigation history.
+    pub fn goForward(self: *BrowserView) void {
+        c.webkit.webkit_web_view_go_forward(self.web_view);
+    }
+
+    /// Reload the current page.
+    pub fn reload(self: *BrowserView) void {
+        c.webkit.webkit_web_view_reload(self.web_view);
+    }
+
+    /// Get the current URI (may be null).
+    pub fn getUri(self: *const BrowserView) ?[*:0]const u8 {
+        return c.webkit.webkit_web_view_get_uri(self.web_view);
+    }
+
+    /// Get the current page title (may be null).
+    pub fn getTitle(self: *const BrowserView) ?[*:0]const u8 {
+        return c.webkit.webkit_web_view_get_title(self.web_view);
+    }
+
+    /// Check if the view can go back.
+    pub fn canGoBack(self: *const BrowserView) bool {
+        return c.webkit.webkit_web_view_can_go_back(self.web_view) != 0;
+    }
+
+    /// Check if the view can go forward.
+    pub fn canGoForward(self: *const BrowserView) bool {
+        return c.webkit.webkit_web_view_can_go_forward(self.web_view) != 0;
+    }
+
+    // ── Signal Handlers ─────────────────────────────────────────────────
+
+    fn onLoadChanged(_: *c.WebKitWebView, load_event: c_uint, view: *BrowserView) callconv(.c) void {
+        // WebKitLoadEvent: 0=STARTED, 1=REDIRECTED, 2=COMMITTED, 3=FINISHED
+        view.is_loading = (load_event != 3);
+    }
+
+    fn onTitleChanged(_: *c.WebKitWebView, _: ?*anyopaque, view: *BrowserView) callconv(.c) void {
+        view.current_title = c.webkit.webkit_web_view_get_title(view.web_view);
+    }
+
+    fn onUriChanged(_: *c.WebKitWebView, _: ?*anyopaque, view: *BrowserView) callconv(.c) void {
+        view.current_url = c.webkit.webkit_web_view_get_uri(view.web_view);
+    }
+};
+
+/// Get the BrowserView from a GtkWidget (if it's a browser panel).
+pub fn fromWidget(widget: *c.GtkWidget) ?*BrowserView {
+    const data = c.gtk.g_object_get_data(@ptrCast(@alignCast(widget)), "cmux-browser");
+    if (data) |d| return @ptrCast(@alignCast(d));
+    return null;
+}

--- a/cmux-linux/src/c_api.zig
+++ b/cmux-linux/src/c_api.zig
@@ -1,5 +1,4 @@
-/// GTK4 and libadwaita C bindings via @cImport.
-/// Ghostty C API bindings.
+/// GTK4, libadwaita, WebKitGTK, and Ghostty C API bindings via @cImport.
 
 const std = @import("std");
 
@@ -9,17 +8,26 @@ pub const gtk = @cImport({
     @cInclude("glib-unix.h");
 });
 
+pub const webkit = @cImport({
+    @cInclude("webkit/webkit.h");
+});
+
 pub const ghostty = @cImport({
     @cInclude("ghostty.h");
 });
 
-// Re-export commonly used types
+// Re-export commonly used GTK types
 pub const GtkWidget = gtk.GtkWidget;
 pub const GtkApplication = gtk.GtkApplication;
 pub const GApplication = gtk.GApplication;
 pub const AdwApplicationWindow = gtk.AdwApplicationWindow;
 pub const AdwHeaderBar = gtk.AdwHeaderBar;
 pub const GtkGLArea = gtk.GtkGLArea;
+
+// WebKitGTK types
+pub const WebKitWebView = webkit.WebKitWebView;
+pub const WebKitSettings = webkit.WebKitSettings;
+pub const WebKitUserContentManager = webkit.WebKitUserContentManager;
 
 // Ghostty types
 pub const ghostty_app_t = ghostty.ghostty_app_t;

--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -1030,7 +1030,7 @@ fn handleBrowserFocusWebview(_: Allocator, params: json.Value) []const u8 {
     for (tm.workspaces.items) |ws| {
         if (ws.panels.get(target_id)) |panel| {
             if (panel.widget) |widget| {
-                c.gtk.gtk_widget_grab_focus(widget);
+                _ = c.gtk.gtk_widget_grab_focus(widget);
                 return "{}";
             }
         }

--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -208,6 +208,14 @@ const methods = .{
     .{ "surface.move", handleSurfaceMove },
     .{ "surface.reorder", handleSurfaceReorder },
     .{ "surface.drag_to_split", handleSurfaceDragToSplit },
+    .{ "browser.open_split", handleBrowserOpenSplit },
+    .{ "browser.navigate", handleBrowserNavigate },
+    .{ "browser.back", handleBrowserBack },
+    .{ "browser.forward", handleBrowserForward },
+    .{ "browser.reload", handleBrowserReload },
+    .{ "browser.url.get", handleBrowserUrlGet },
+    .{ "browser.focus_webview", handleBrowserFocusWebview },
+    .{ "browser.is_webview_focused", handleBrowserIsWebviewFocused },
     .{ "notification.create", handleNotificationCreate },
     .{ "notification.list", handleNotificationList },
     .{ "notification.clear", handleNotificationClear },
@@ -323,7 +331,7 @@ fn handleIdentify(alloc: Allocator, _: json.Value) []const u8 {
 }
 
 fn handleCapabilities(_: Allocator, _: json.Value) []const u8 {
-    return "{\"workspaces\":true,\"splits\":true,\"notifications\":true,\"browser\":false,\"session\":true}";
+    return "{\"workspaces\":true,\"splits\":true,\"notifications\":true,\"browser\":true,\"session\":true}";
 }
 
 // ── Window Handlers ─────────────────────────────────────────────────────
@@ -879,6 +887,175 @@ fn handleSurfaceReorder(_: Allocator, params: json.Value) []const u8 {
 fn handleSurfaceDragToSplit(alloc: Allocator, params: json.Value) []const u8 {
     // Same as surface.split but semantically "dragging" an existing surface
     return handleSurfaceSplit(alloc, params);
+}
+
+// ── Browser Handlers ────────────────────────────────────────────────────
+
+const browser_mod = @import("browser.zig");
+
+fn handleBrowserOpenSplit(alloc: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+    const ws = tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+    const url = getParamString(params, "url");
+
+    const panel = ws.createBrowserPanel(url) catch return "{\"error\":\"create browser failed\"}";
+
+    // Add to split tree
+    if (ws.root_node) |root| {
+        const focused_id = ws.focused_panel_id orelse panel.id;
+        if (split_tree.findLeaf(root, focused_id)) |_| {
+            ws.root_node = split_tree.splitPane(ws.alloc, root, .horizontal, panel.id, panel.widget) catch return "{\"error\":\"split failed\"}";
+        }
+    } else {
+        ws.root_node = split_tree.createLeaf(ws.alloc, panel.id, panel.widget) catch return "{\"error\":\"create leaf failed\"}";
+    }
+    ws.content_widget = split_tree.buildWidget(ws.root_node.?);
+    ws.focused_panel_id = panel.id;
+    if (window.getSidebar()) |sb| sb.refresh();
+
+    const panel_hex = formatId(panel.id);
+    return std.fmt.allocPrint(alloc, "{{\"surface_id\":\"{s}\"}}", .{@as([]const u8, &panel_hex)}) catch "{}";
+}
+
+fn handleBrowserNavigate(_: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+    const url = getParamString(params, "url") orelse return "{\"error\":\"missing url\"}";
+
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        parseId(id_str) orelse return "{\"error\":\"invalid surface_id\"}"
+    else blk: {
+        const ws = tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+        break :blk ws.focused_panel_id orelse return "{\"error\":\"no focused surface\"}";
+    };
+
+    // Find the panel and its browser view
+    for (tm.workspaces.items) |ws| {
+        if (ws.panels.get(target_id)) |panel| {
+            if (panel.panel_type == .browser) {
+                if (panel.widget) |widget| {
+                    if (browser_mod.fromWidget(widget)) |bv| {
+                        const alloc = std.heap.c_allocator;
+                        const url_z = alloc.dupeZ(u8, url) catch return "{\"error\":\"alloc failed\"}";
+                        defer alloc.free(url_z);
+                        bv.navigate(url_z);
+                        return "{}";
+                    }
+                }
+            }
+            return "{\"error\":\"not a browser panel\"}";
+        }
+    }
+    return "{\"error\":\"surface not found\"}";
+}
+
+fn handleBrowserBack(_: Allocator, params: json.Value) []const u8 {
+    return browserAction(params, .back);
+}
+
+fn handleBrowserForward(_: Allocator, params: json.Value) []const u8 {
+    return browserAction(params, .forward);
+}
+
+fn handleBrowserReload(_: Allocator, params: json.Value) []const u8 {
+    return browserAction(params, .reload);
+}
+
+const BrowserAction = enum { back, forward, reload };
+
+fn browserAction(params: json.Value, action: BrowserAction) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        parseId(id_str) orelse return "{\"error\":\"invalid surface_id\"}"
+    else blk: {
+        const ws = tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+        break :blk ws.focused_panel_id orelse return "{\"error\":\"no focused surface\"}";
+    };
+
+    for (tm.workspaces.items) |ws| {
+        if (ws.panels.get(target_id)) |panel| {
+            if (panel.panel_type == .browser) {
+                if (panel.widget) |widget| {
+                    if (browser_mod.fromWidget(widget)) |bv| {
+                        switch (action) {
+                            .back => bv.goBack(),
+                            .forward => bv.goForward(),
+                            .reload => bv.reload(),
+                        }
+                        return "{}";
+                    }
+                }
+            }
+            return "{\"error\":\"not a browser panel\"}";
+        }
+    }
+    return "{\"error\":\"surface not found\"}";
+}
+
+fn handleBrowserUrlGet(alloc: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        parseId(id_str) orelse return "{\"error\":\"invalid surface_id\"}"
+    else blk: {
+        const ws = tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+        break :blk ws.focused_panel_id orelse return "{\"error\":\"no focused surface\"}";
+    };
+
+    for (tm.workspaces.items) |ws| {
+        if (ws.panels.get(target_id)) |panel| {
+            if (panel.panel_type == .browser) {
+                if (panel.widget) |widget| {
+                    if (browser_mod.fromWidget(widget)) |bv| {
+                        if (bv.getUri()) |uri| {
+                            return std.fmt.allocPrint(alloc, "{{\"url\":\"{s}\"}}", .{uri}) catch "{}";
+                        }
+                        return "{\"url\":\"\"}";
+                    }
+                }
+            }
+            return "{\"error\":\"not a browser panel\"}";
+        }
+    }
+    return "{\"error\":\"surface not found\"}";
+}
+
+fn handleBrowserFocusWebview(_: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        parseId(id_str) orelse return "{\"error\":\"invalid surface_id\"}"
+    else blk: {
+        const ws = tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+        break :blk ws.focused_panel_id orelse return "{\"error\":\"no focused surface\"}";
+    };
+
+    for (tm.workspaces.items) |ws| {
+        if (ws.panels.get(target_id)) |panel| {
+            if (panel.widget) |widget| {
+                c.gtk.gtk_widget_grab_focus(widget);
+                return "{}";
+            }
+        }
+    }
+    return "{\"error\":\"surface not found\"}";
+}
+
+fn handleBrowserIsWebviewFocused(_: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"focused\":false}";
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        parseId(id_str) orelse return "{\"focused\":false}"
+    else blk: {
+        const ws = tm.selectedWorkspace() orelse return "{\"focused\":false}";
+        break :blk ws.focused_panel_id orelse return "{\"focused\":false}";
+    };
+
+    for (tm.workspaces.items) |ws| {
+        if (ws.panels.get(target_id)) |panel| {
+            if (panel.widget) |widget| {
+                const focused = c.gtk.gtk_widget_has_focus(widget) != 0;
+                return if (focused) "{\"focused\":true}" else "{\"focused\":false}";
+            }
+        }
+    }
+    return "{\"focused\":false}";
 }
 
 // ── Batch 5: Notification Stubs ─────────────────────────────────────────

--- a/cmux-linux/src/workspace.zig
+++ b/cmux-linux/src/workspace.zig
@@ -22,6 +22,7 @@ pub const Panel = struct {
     title: ?[]const u8 = null,
     custom_title: ?[]const u8 = null,
     directory: ?[]const u8 = null,
+    url: ?[]const u8 = null,
     is_pinned: bool = false,
     is_manually_unread: bool = false,
     git_branch: ?[]const u8 = null,
@@ -104,6 +105,25 @@ pub const Workspace = struct {
 
         // Create the surface widget
         const widget = try @import("surface.zig").Surface.create(ghostty_app);
+        panel.widget = widget;
+
+        try self.panels.put(self.alloc, id, panel);
+        self.focused_panel_id = id;
+        return panel;
+    }
+
+    /// Create a new browser panel in this workspace.
+    pub fn createBrowserPanel(self: *Workspace, url: ?[]const u8) !*Panel {
+        const id = generateId();
+        const panel = try self.alloc.create(Panel);
+        panel.* = .{
+            .id = id,
+            .panel_type = .browser,
+            .url = if (url) |u| self.alloc.dupe(u8, u) catch null else null,
+        };
+
+        // Create the WebKitGTK browser widget
+        const widget = try @import("browser.zig").BrowserView.create(url);
         panel.widget = widget;
 
         try self.panels.put(self.alloc, id, panel);


### PR DESCRIPTION
## Summary

First browser panel implementation for cmux-linux using WebKitGTK 6.0.

- New browser.zig module: WebKitWebView lifecycle, navigation, signals
- WebKitGTK linked via pkg-config (webkitgtk-6.0)
- workspace.zig: createBrowserPanel(url) alongside createTerminalPanel
- 8 new socket methods: browser.open_split, navigate, back/forward/reload, url.get, focus/is_focused
- Capabilities updated: "browser": true
- Panel.url field for URL tracking

## Test plan

- [ ] Fedora CI: WebKitGTK available, builds clean
- [ ] Ubuntu CI: May need webkitgtk6 package added
- [ ] Arch CI: WebKitGTK available
- [ ] Honey GPU test: browser panel creation via socket