### PR TITLE
M5b Sprint 4+5: DevTools, find-in-page, media permissions (#89, #90)

### DIFF
--- a/cmux-linux/src/browser.zig
+++ b/cmux-linux/src/browser.zig
@@ -88,6 +88,16 @@ pub const BrowserView = struct {
             0,
         );
 
+        // Handle media permission requests (camera/microphone for Google Meet, Zoom)
+        _ = c.gtk.g_signal_connect_data(
+            @ptrCast(@alignCast(web_view)),
+            "permission-request",
+            @ptrCast(&onPermissionRequest),
+            view,
+            null,
+            0,
+        );
+
         // Install WebAuthn bridge for FIDO2/YubiKey support
         const webauthn = alloc.create(WebAuthnBridge) catch null;
         if (webauthn) |wa| {
@@ -151,6 +161,57 @@ pub const BrowserView = struct {
         return c.webkit.webkit_web_view_can_go_forward(self.web_view) != 0;
     }
 
+    // ── DevTools (Inspector) ───────────────────────────────────────────
+
+    /// Show the web inspector (F12 developer tools).
+    pub fn showInspector(self: *BrowserView) void {
+        const inspector = c.webkit.webkit_web_view_get_inspector(self.web_view) orelse return;
+        c.webkit.webkit_web_inspector_show(inspector);
+    }
+
+    /// Close the web inspector.
+    pub fn closeInspector(self: *BrowserView) void {
+        const inspector = c.webkit.webkit_web_view_get_inspector(self.web_view) orelse return;
+        c.webkit.webkit_web_inspector_close(inspector);
+    }
+
+    /// Attach the inspector to the web view (inline).
+    pub fn attachInspector(self: *BrowserView) void {
+        const inspector = c.webkit.webkit_web_view_get_inspector(self.web_view) orelse return;
+        c.webkit.webkit_web_inspector_attach(inspector);
+    }
+
+    // ── Find in Page ────────────────────────────────────────────────────
+
+    /// Start a find-in-page search.
+    pub fn findText(self: *BrowserView, query: [*:0]const u8) void {
+        const controller = c.webkit.webkit_web_view_get_find_controller(self.web_view) orelse return;
+        c.webkit.webkit_find_controller_search(
+            controller,
+            query,
+            c.webkit.WEBKIT_FIND_OPTIONS_CASE_INSENSITIVE | c.webkit.WEBKIT_FIND_OPTIONS_WRAP_AROUND,
+            0, // max_match_count (0 = unlimited)
+        );
+    }
+
+    /// Find the next match.
+    pub fn findNext(self: *BrowserView) void {
+        const controller = c.webkit.webkit_web_view_get_find_controller(self.web_view) orelse return;
+        c.webkit.webkit_find_controller_search_next(controller);
+    }
+
+    /// Find the previous match.
+    pub fn findPrevious(self: *BrowserView) void {
+        const controller = c.webkit.webkit_web_view_get_find_controller(self.web_view) orelse return;
+        c.webkit.webkit_find_controller_search_previous(controller);
+    }
+
+    /// Clear the find highlighting.
+    pub fn findFinish(self: *BrowserView) void {
+        const controller = c.webkit.webkit_web_view_get_find_controller(self.web_view) orelse return;
+        c.webkit.webkit_find_controller_search_finish(controller);
+    }
+
     // ── Signal Handlers ─────────────────────────────────────────────────
 
     fn onLoadChanged(_: *c.WebKitWebView, load_event: c_uint, view: *BrowserView) callconv(.c) void {
@@ -164,6 +225,24 @@ pub const BrowserView = struct {
 
     fn onUriChanged(_: *c.WebKitWebView, _: ?*anyopaque, view: *BrowserView) callconv(.c) void {
         view.current_url = c.webkit.webkit_web_view_get_uri(view.web_view);
+    }
+
+    /// Handle media permission requests (camera/microphone).
+    /// Auto-allows for now — a permission dialog can be added later.
+    fn onPermissionRequest(
+        _: *c.WebKitWebView,
+        request: ?*anyopaque,
+        _: *BrowserView,
+    ) callconv(.c) c.gtk.gboolean {
+        if (request) |req| {
+            // Check if this is a user media (camera/mic) request
+            if (c.webkit.WEBKIT_IS_USER_MEDIA_PERMISSION_REQUEST(req) != 0) {
+                log.info("Media permission requested — granting", .{});
+                c.webkit.webkit_permission_request_allow(@ptrCast(req));
+                return 1; // handled
+            }
+        }
+        return 0; // not handled, use default behavior
     }
 };
 

--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -216,6 +216,12 @@ const methods = .{
     .{ "browser.url.get", handleBrowserUrlGet },
     .{ "browser.focus_webview", handleBrowserFocusWebview },
     .{ "browser.is_webview_focused", handleBrowserIsWebviewFocused },
+    .{ "browser.show_devtools", handleBrowserShowDevtools },
+    .{ "browser.close_devtools", handleBrowserCloseDevtools },
+    .{ "browser.find", handleBrowserFind },
+    .{ "browser.find_next", handleBrowserFindNext },
+    .{ "browser.find_previous", handleBrowserFindPrevious },
+    .{ "browser.find_finish", handleBrowserFindFinish },
     .{ "notification.create", handleNotificationCreate },
     .{ "notification.list", handleNotificationList },
     .{ "notification.clear", handleNotificationClear },
@@ -1056,6 +1062,88 @@ fn handleBrowserIsWebviewFocused(_: Allocator, params: json.Value) []const u8 {
         }
     }
     return "{\"focused\":false}";
+}
+
+// ── DevTools + Find Handlers ────────────────────────────────────────────
+
+fn handleBrowserShowDevtools(_: Allocator, params: json.Value) []const u8 {
+    return browserViewAction(params, .show_devtools);
+}
+
+fn handleBrowserCloseDevtools(_: Allocator, params: json.Value) []const u8 {
+    return browserViewAction(params, .close_devtools);
+}
+
+fn handleBrowserFind(_: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        parseId(id_str) orelse return "{\"error\":\"invalid surface_id\"}"
+    else blk: {
+        const ws = tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+        break :blk ws.focused_panel_id orelse return "{\"error\":\"no focused surface\"}";
+    };
+    const query = getParamString(params, "query") orelse return "{\"error\":\"missing query\"}";
+
+    for (tm.workspaces.items) |ws| {
+        if (ws.panels.get(target_id)) |panel| {
+            if (panel.panel_type == .browser) {
+                if (panel.widget) |widget| {
+                    if (browser_mod.fromWidget(widget)) |bv| {
+                        const alloc = std.heap.c_allocator;
+                        const query_z = alloc.dupeZ(u8, query) catch return "{\"error\":\"alloc\"}";
+                        defer alloc.free(query_z);
+                        bv.findText(query_z);
+                        return "{}";
+                    }
+                }
+            }
+        }
+    }
+    return "{\"error\":\"surface not found\"}";
+}
+
+fn handleBrowserFindNext(_: Allocator, params: json.Value) []const u8 {
+    return browserViewAction(params, .find_next);
+}
+
+fn handleBrowserFindPrevious(_: Allocator, params: json.Value) []const u8 {
+    return browserViewAction(params, .find_previous);
+}
+
+fn handleBrowserFindFinish(_: Allocator, params: json.Value) []const u8 {
+    return browserViewAction(params, .find_finish);
+}
+
+const BrowserViewAction = enum { show_devtools, close_devtools, find_next, find_previous, find_finish };
+
+fn browserViewAction(params: json.Value, action: BrowserViewAction) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        parseId(id_str) orelse return "{\"error\":\"invalid surface_id\"}"
+    else blk: {
+        const ws = tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+        break :blk ws.focused_panel_id orelse return "{\"error\":\"no focused surface\"}";
+    };
+
+    for (tm.workspaces.items) |ws| {
+        if (ws.panels.get(target_id)) |panel| {
+            if (panel.panel_type == .browser) {
+                if (panel.widget) |widget| {
+                    if (browser_mod.fromWidget(widget)) |bv| {
+                        switch (action) {
+                            .show_devtools => bv.showInspector(),
+                            .close_devtools => bv.closeInspector(),
+                            .find_next => bv.findNext(),
+                            .find_previous => bv.findPrevious(),
+                            .find_finish => bv.findFinish(),
+                        }
+                        return "{}";
+                    }
+                }
+            }
+        }
+    }
+    return "{\"error\":\"surface not found\"}";
 }
 
 // ── Batch 5: Notification Stubs ─────────────────────────────────────────


### PR DESCRIPTION
Completes the M5b milestone with the last two features:

DevTools + Find-in-page (#89):
- WebKitWebInspector show/close/attach via socket commands
- WebKitFindController search/next/previous/finish
- 6 new socket methods

Media capture permissions (#90):
- permission-request signal handler for camera/microphone
- Auto-allows for now (custom dialog in follow-up)

Socket total: 59 JSON-RPC methods. This closes all 5 M5b issues.