### PR TITLE
fix(ci): resolve SIGPIPE in upstream sync workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -62,8 +62,8 @@ jobs:
 
           COMMIT_COUNT="${{ steps.check.outputs.commit_count }}"
 
-          # Collect commit subjects
-          COMMITS=$(git log HEAD..upstream/main --pretty=format:"- %h %s" --no-merges | head -50)
+          # Collect commit subjects (use tail-pipe pattern to avoid SIGPIPE from head under pipefail)
+          COMMITS=$(git log HEAD..upstream/main --pretty=format:"- %h %s" --no-merges -50)
 
           # Classify changed files for risk assessment
           CHANGED_FILES=$(git diff HEAD..upstream/main --name-only)


### PR DESCRIPTION
## Summary
- Fix exit code 141 (SIGPIPE) in upstream-sync.yml changelog generation step
- `git log | head -50` causes SIGPIPE under `set -euo pipefail` — use `git log -50` instead

This has been failing on the last 2 scheduled runs, blocking automated upstream sync.

## Test plan
- [ ] Trigger upstream sync manually: `gh workflow run upstream-sync.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)