### PR TITLE
fix(ci): install systemd-rpm-macros for RPM udev rules

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Install build dependencies
         run: |
           dnf install -y \
-            git rpm-build \
+            git rpm-build systemd-rpm-macros \
             gcc gcc-c++ pkg-config \
             gtk4-devel libadwaita-devel \
             webkitgtk6.0-devel \


### PR DESCRIPTION
## Summary
RPM build fails with `File must begin with "/": %{_udevrulesdir}/70-u2f.rules` because the `%{_udevrulesdir}` macro is undefined. It's provided by `systemd-rpm-macros` which wasn't in the Fedora container's dependency list.

Third and hopefully final fix for the RPM packaging pipeline (after #143 version hyphen, #145 buildroot paths).

## Test plan
- [ ] Merge, dispatch `release-linux.yml` with `tag=lab-v0.73.0-test3`
- [ ] All three jobs pass (DEB, RPM, Upload)