### PR TITLE
fix(ui): M6 bug fixes — drag stuck, D&D paths, browser arrow keys

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9601,6 +9601,9 @@ private struct SidebarExternalDropDelegate: DropDelegate {
 #if DEBUG
         dlog("sidebar.dropOutside.exited tab=\(debugShortSidebarTabId(draggedTabId))")
 #endif
+        if !CGEventSource.buttonState(.combinedSessionState, button: .left) {
+            SidebarDragLifecycleNotification.postClearRequest(reason: "outside_drop_exited_mouse_up")
+        }
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
@@ -13409,6 +13412,15 @@ private struct SidebarTabDropDelegate: DropDelegate {
 #endif
         if dropIndicator?.tabId == targetTabId {
             dropIndicator = nil
+        }
+        // If the mouse button is no longer down, the drag session has ended
+        // without performDrop (e.g. dropped outside valid targets). Clear
+        // immediately rather than waiting for the failsafe timer.
+        if !CGEventSource.buttonState(.combinedSessionState, button: .left) {
+#if DEBUG
+            dlog("sidebar.dropExited.mouseUpClear target=\(targetTabId?.uuidString.prefix(5) ?? "end")")
+#endif
+            draggedTabId = nil
         }
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -638,6 +638,14 @@ struct BrowserPanelView: View {
                 panel.invalidateAddressBarPageFocusRestoreAttempts()
                 hideSuggestions()
                 setAddressBarFocused(false, reason: "panelFocus.onChange.unfocused")
+                // If the WebView is still first responder, resign it so the terminal
+                // can receive keyboard events (arrow keys, etc.) immediately.
+                let webView = panel.webView
+                if let window = webView.window,
+                   let responderView = window.firstResponder as? NSView,
+                   responderView === webView || responderView.isDescendant(of: webView) {
+                    window.makeFirstResponder(nil)
+                }
                 // Surface switches in split layouts can keep the browser visible, so
                 // `isVisibleInUI` never flips to false. Check for an attached-inspector
                 // X-close when focus leaves as well so the persisted intent stays in sync.

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -266,6 +266,9 @@ enum TerminalImageTransferPlanner {
         }
 
         if let rawURL = pasteboard.string(forType: .URL), !rawURL.isEmpty {
+            if let url = URL(string: rawURL), url.isFileURL {
+                return .insertText(escapeForShell(url.path))
+            }
             return .insertText(escapeForShell(rawURL))
         }
 
@@ -281,6 +284,10 @@ enum TerminalImageTransferPlanner {
         }
 
         if let rawURL = pasteboard.string(forType: .URL), !rawURL.isEmpty {
+            // Convert file:// URLs to POSIX paths for terminal insertion
+            if let url = URL(string: rawURL), url.isFileURL {
+                return .insertText(escapeForShell(url.path))
+            }
             return .insertText(escapeForShell(rawURL))
         }
 

--- a/TODO.md
+++ b/TODO.md
@@ -43,7 +43,7 @@
 
 ## Refactoring
 - [ ] **P0** Remove all index-based APIs in favor of short ID refs (surface:N, pane:N, workspace:N, window:N)
-- [ ] **P0** CLI commands should be workspace-relative using CMUX_WORKSPACE_ID env var (not focused workspace) so agents in background workspaces don't affect the user's active workspace. Affected: send, send-key, send-panel, send-key-panel, new-split, new-pane, new-surface, close-surface, list-panes, list-pane-surfaces, list-panels, focus-pane, focus-panel, surface-health
+- [x] **P0** CLI commands should be workspace-relative using CMUX_WORKSPACE_ID env var (PR #89)
 
 ## UI/UX Improvements
 - [ ] Show loading indicator in terminal while it's loading


### PR DESCRIPTION
## Summary

Three bug fixes from M6: Release Polish milestone.

- **#155 Sidebar drag stuck**: `dropExited` now checks `CGEventSource.buttonState` — if mouse is already up when the delegate exits, clear drag state immediately rather than waiting for the failsafe timer
- **#156 D&D file paths**: `prepareDrop` and `preparePaste` now convert `file://` URLs to POSIX paths via `URL.path` before shell-escaping, instead of inserting the raw URL string
- **#157 Arrow keys after browser**: When browser panel loses focus, explicitly resign WebView first responder if it's still active, so the terminal can receive keyboard events

Also marks workspace-relative CLI (CMUX_WORKSPACE_ID) as complete in TODO.md — already shipped in PR #89.

Closes #155, closes #156, closes #157

## Test plan

- [ ] Drag a sidebar tab, drop outside the sidebar → tab should not stay dimmed
- [ ] Drag a file from Finder into the terminal → should insert `/path/to/file` not `file:///path/to/file`
- [ ] Open a browser tab, then switch to a terminal tab → arrow keys should work immediately