### PR TITLE
fix(ci): strip xcframework tags in fork-release.yml

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Strip non-version tags from ghostty
+        run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true
+
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:


### PR DESCRIPTION
The Xcode build phase invokes `zig build` for the Ghostty CLI helper, which triggers the same tag panic as the other workflows. Adds the tag-stripping step to unblock macOS DMG release.