### PR TITLE
feat(ui): warm Claude Code pool with Cmd+Shift+K

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2294,6 +2294,19 @@ struct CMUXCLI {
             cliTelemetry.breadcrumb("claude-setup.dispatch")
             try runClaudeSetup(client: client)
 
+        case "new-claude":
+            cliTelemetry.breadcrumb("new-claude.dispatch")
+            let response = try client.sendV2(
+                method: "workspace.create",
+                params: ["title": "Claude Code"]
+            )
+            let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
+            if !wsId.isEmpty {
+                let text = unescapeSendText("claude\\n")
+                _ = try client.sendV2(method: "surface.send_text", params: ["text": text, "workspace_id": wsId])
+            }
+            print("OK \(wsId)")
+
         case "claude-hook":
             cliTelemetry.breadcrumb("claude-hook.dispatch")
             do {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6325,6 +6325,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    func openClaudeFromPool() {
+        guard let context = preferredMainWindowContextForWorkspaceCreation(event: nil, debugSource: "claude_pool") else {
+            return
+        }
+        if let window = context.window ?? windowForMainWindowId(context.windowId) {
+            setActiveMainWindow(window)
+            bringToFront(window)
+        }
+        if let _ = context.tabManager.claimWarmClaudeWorkspace() {
+            // Pool hit — workspace already selected by claimWarmClaudeWorkspace
+        } else {
+            // Pool miss — create fresh
+            context.tabManager.addWorkspace(
+                title: "Claude Code",
+                initialTerminalCommand: "claude",
+                eagerLoadTerminal: true,
+                placementOverride: .end
+            )
+        }
+    }
+
     func openWelcomeWorkspace() {
         guard let context = preferredMainWindowContextForWorkspaceCreation(event: nil, debugSource: "welcome") else {
             return

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -693,6 +693,7 @@ class TabManager: ObservableObject {
     @Published private(set) var isWorkspaceCycleHot: Bool = false
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
+    @Published private(set) var warmClaudePoolIds: [UUID] = []
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
@@ -2182,6 +2183,56 @@ class TabManager: ObservableObject {
         var updated = pendingBackgroundWorkspaceLoadIds
         updated.remove(workspaceId)
         pendingBackgroundWorkspaceLoadIds = updated
+    }
+
+    // MARK: - Warm Claude Code Pool
+
+    func ensureWarmClaudePool() {
+        let targetSize = WarmClaudePoolSettings.poolSize()
+        guard targetSize > 0 else {
+            // Drain pool if disabled
+            if !warmClaudePoolIds.isEmpty {
+                let idsToClose = warmClaudePoolIds
+                warmClaudePoolIds = []
+                for wsId in idsToClose {
+                    if let ws = tabs.first(where: { $0.id == wsId }) {
+                        closeWorkspace(ws)
+                    }
+                }
+            }
+            return
+        }
+
+        // Remove stale IDs (workspaces that were closed by the user)
+        warmClaudePoolIds.removeAll { wsId in
+            !tabs.contains { $0.id == wsId }
+        }
+
+        // Spawn new entries up to target size
+        while warmClaudePoolIds.count < targetSize {
+            let ws = addWorkspace(
+                title: "Claude Code",
+                initialTerminalCommand: "claude",
+                select: false,
+                eagerLoadTerminal: true,
+                placementOverride: .end,
+                autoWelcomeIfNeeded: false
+            )
+            warmClaudePoolIds.append(ws.id)
+        }
+    }
+
+    func claimWarmClaudeWorkspace() -> Workspace? {
+        guard let wsId = warmClaudePoolIds.first else { return nil }
+        warmClaudePoolIds.removeFirst()
+        guard let ws = tabs.first(where: { $0.id == wsId }) else { return nil }
+        // Select the claimed workspace
+        selectedTabId = ws.id
+        // Backfill the pool after a short delay to avoid blocking the UI
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.ensureWarmClaudePool()
+        }
+        return ws
     }
 
     func retainDebugWorkspaceLoads(for workspaceIds: Set<UUID>) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -624,6 +624,13 @@ struct cmuxApp: App {
 
             // Close tab/workspace
             CommandGroup(after: .newItem) {
+                Button(String(localized: "menu.file.newClaude", defaultValue: "New Claude Code")) {
+                    AppDelegate.shared?.openClaudeFromPool()
+                }
+                .keyboardShortcut("k", modifiers: [.command, .shift])
+
+                Divider()
+
                 Button(String(localized: "menu.file.goToWorkspace", defaultValue: "Go to Workspace…")) {
                     let targetWindow = NSApp.keyWindow ?? NSApp.mainWindow
                     NotificationCenter.default.post(name: .commandPaletteSwitcherRequested, object: targetWindow)
@@ -3959,6 +3966,16 @@ enum ClaudeCodeIntegrationSettings {
     }
 }
 
+enum WarmClaudePoolSettings {
+    static let poolSizeKey = "warmClaudePoolSize"
+    static let defaultPoolSize = 0
+
+    static func poolSize(defaults: UserDefaults = .standard) -> Int {
+        let raw = defaults.integer(forKey: poolSizeKey)
+        return max(0, min(raw, 3))
+    }
+}
+
 enum WelcomeSettings {
     static let shownKey = "cmuxWelcomeShown"
 }
@@ -4040,6 +4057,8 @@ struct SettingsView: View {
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
+    @AppStorage(WarmClaudePoolSettings.poolSizeKey)
+    private var warmClaudePoolSize = WarmClaudePoolSettings.defaultPoolSize
     @AppStorage("cmuxPortBase") private var cmuxPortBase = 9100
     @AppStorage("cmuxPortRange") private var cmuxPortRange = 10
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
@@ -5425,6 +5444,21 @@ struct SettingsView: View {
                             )
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 200)
+                        }
+                    }
+
+                    SettingsCard {
+                        SettingsCardRow(
+                            String(localized: "settings.automation.warmClaudePool", defaultValue: "Warm Claude Pool"),
+                            subtitle: warmClaudePoolSize > 0
+                                ? String(localized: "settings.automation.warmClaudePool.subtitleOn", defaultValue: "Pre-spawns Claude Code sessions for instant launch via ⇧⌘K.")
+                                : String(localized: "settings.automation.warmClaudePool.subtitleOff", defaultValue: "Claude Code sessions launch on demand (no pre-warming).")
+                        ) {
+                            Stepper(value: $warmClaudePoolSize, in: 0...3) {
+                                Text("\(warmClaudePoolSize)")
+                                    .monospacedDigit()
+                            }
+                            .frame(width: 100)
                         }
                     }
 


### PR DESCRIPTION
## Summary

Pre-spawn configurable pool of Claude Code terminal sessions for instant launch (#171).

- **Settings**: Pool size stepper (0-3) in Automation section. 0 = disabled (default).
- **Pool manager**: `TabManager.warmClaudePoolIds` tracked as published state. `ensureWarmClaudePool()` spawns workspaces with `select: false, eagerLoadTerminal: true` (uses existing background priming). `claimWarmClaudeWorkspace()` pops first entry and backfills after 0.5s.
- **Menu + shortcut**: "New Claude Code" (Cmd+Shift+K) in File menu
- **AppDelegate**: `openClaudeFromPool()` — pool hit = instant switch, pool miss = fresh create
- **CLI**: `cmux new-claude` creates a workspace + sends `claude` command

Closes #171

## Test plan

- [ ] Set pool size to 1 → "Claude Code" workspace appears in sidebar
- [ ] Cmd+Shift+K → switches to pre-warmed session instantly
- [ ] Another "Claude Code" workspace spawns to backfill
- [ ] Pool size 0 → no pre-spawning, Cmd+Shift+K creates fresh
- [ ] Close a pool workspace → pool backfills
- [ ] Fork CI macOS build passes