### PR TITLE
ci: add workflow_dispatch to build-ghosttykit

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build-ghosttykit:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: macos-15
     timeout-minutes: 20
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` trigger to `build-ghosttykit.yml` so xcframework builds can be triggered manually.

Currently the workflow only fires on push to main, which means:
- If the workflow was disabled when a push happened, it can't be retriggered
- Can't rebuild xcframework without a code change

This unblocks the lab-v0.74.0 macOS release (xcframework for ghostty `22d1cdd7` is missing).

## Test plan
- [ ] CI passes
- [ ] After merge: `gh workflow run build-ghosttykit.yml` triggers successfully