### PR TITLE
ci: migrate Nix cache from magic-nix-cache to FlakeHub Cache

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -74,6 +74,9 @@ jobs:
   nix-check:
     name: Nix flake check
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,12 +85,10 @@ jobs:
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          # relaxed sandbox allows __noChroot derivations (needed for
-          # libghostty: Zig build-time tools require /lib64 dynamic linker)
           extra-conf: "sandbox = relaxed"
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@v3
 
       - name: Verify dev shell
         run: nix develop --command bash -c 'echo "zig $(zig version) — dev shell OK"'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -26,6 +26,9 @@ jobs:
   nix-flake:
     name: Nix flake check
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,12 +37,10 @@ jobs:
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          # relaxed sandbox allows __noChroot derivations (needed for
-          # libghostty: Zig build-time tools require /lib64 dynamic linker)
           extra-conf: "sandbox = relaxed"
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@v3
 
       - name: Verify dev shell
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -212,7 +212,12 @@
   };
 
   nixConfig = {
-    extra-substituters = ["https://ghostty.cachix.org"];
-    extra-trusted-public-keys = ["ghostty.cachix.org-1:QB389yTa6gTyneehvqG58y0WnHjQOqgnA+wBnpWWxns="];
+    extra-substituters = [
+      "https://ghostty.cachix.org"
+      "https://cache.flakehub.com"
+    ];
+    extra-trusted-public-keys = [
+      "ghostty.cachix.org-1:QB389yTa6gTyneehvqG58y0WnHjQOqgnA+wBnpWWxns="
+    ];
   };
 }


### PR DESCRIPTION
## Summary
- Replace `magic-nix-cache-action` with `flakehub-cache-action@v3` in fork-ci.yml and linux-ci.yml
- Add `cache.flakehub.com` to flake.nix nixConfig substituters
- Add `id-token: write` permissions for OIDC authentication (zero secrets)

FlakeHub Cache provides persistent CDN-backed binary caching, eliminating
cold-cache rebuilds of libghostty (~30 native deps). Part of the
Attic → FlakeHub migration for tinyland-inc org.

## Test plan
- [ ] fork-ci nix-check job authenticates with FlakeHub Cache
- [ ] linux-ci nix-flake job authenticates with FlakeHub Cache
- [ ] CI logs show "pushed N paths" after builds
- [ ] macOS LAB build unaffected (no Nix changes)