### PR TITLE
docs: add Linux QA roadmap and shard plan

### DIFF
--- a/docs/linear-qa-shard-punchlist.md
+++ b/docs/linear-qa-shard-punchlist.md
@@ -1,0 +1,428 @@
+# Linear-Ready QA Shard Punchlist
+
+This document is a sharding sheet for QA testers and parallel implementation
+work.
+
+It is designed to be easy to split into Linear issues, GitHub issues, or manual
+work assignments without re-deriving scope from the codebase.
+
+Use it with:
+
+- [program-review-2026-04-14.md](/Users/jess/git/cmux/docs/program-review-2026-04-14.md:1)
+- [linux-work-week-2026-04-14.md](/Users/jess/git/cmux/docs/linux-work-week-2026-04-14.md:1)
+- [linux-parity-matrix.md](/Users/jess/git/cmux/docs/linux-parity-matrix.md:1)
+- [linux-validation-checklist.md](/Users/jess/git/cmux/docs/linux-validation-checklist.md:1)
+- [component-portfolio.md](/Users/jess/git/cmux/docs/component-portfolio.md:1)
+- [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:1)
+
+## Instructions For Sharding
+
+Each shard should capture:
+
+- exact distro or component under test
+- exact artifact or branch under test
+- pass/fail result
+- evidence
+- blocker if any
+- follow-up recommendation
+
+Preferred evidence:
+
+- package filename and version
+- image or VM version
+- screenshots when UI behavior matters
+- command output for install/runtime failures
+- log excerpt for actionable failures
+
+## Lane 1: Governance And Tracker Hygiene
+
+### GOV-001 Merge Linux Hygiene Stack
+
+- Type: repo hygiene
+- Priority: `P0`
+- Goal: merge `#205` and stabilize the repo on `main`
+- References:
+  - [PR #205](https://github.com/Jesssullivan/cmux/pull/205)
+  - [program-status.md](/Users/jess/git/cmux/docs/program-status.md:1)
+- Exit criteria:
+  - `#205` merged
+  - post-merge Linux CI remains green
+
+### GOV-002 Refresh Linux Umbrella Issue
+
+- Type: tracker
+- Priority: `P0`
+- Goal: refresh `#55` so it reflects current implementation and proof work
+- References:
+  - [tracker-refresh-drafts.md](/Users/jess/git/cmux/docs/tracker-refresh-drafts.md:54)
+  - [linux-program-plan.md](/Users/jess/git/cmux/docs/linux-program-plan.md:15)
+- Exit criteria:
+  - `#55` describes current Linux program reality, not greenfield architecture
+
+### GOV-003 Refresh Rocky 10 Tracking
+
+- Type: tracker
+- Priority: `P0`
+- Goal: refresh `#187` to reflect Rocky 10 GA and the actual `nix-vm-test`
+  blocker
+- References:
+  - [tracker-refresh-drafts.md](/Users/jess/git/cmux/docs/tracker-refresh-drafts.md:8)
+  - [nix/tests-distro.nix](/Users/jess/git/cmux/nix/tests-distro.nix:156)
+- Exit criteria:
+  - `#187` reflects current Rocky reality and proxy coverage correctly
+
+### GOV-004 Refresh Fork Landscape Issue
+
+- Type: tracker
+- Priority: `P1`
+- Goal: refresh `#199` so it reflects current divergence and manual-upstream
+  boundaries
+- References:
+  - [tracker-refresh-drafts.md](/Users/jess/git/cmux/docs/tracker-refresh-drafts.md:108)
+  - [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:31)
+- Exit criteria:
+  - `#199` matches current repo graph and manual-submission policy
+
+### GOV-005 Milestone Cleanup
+
+- Type: tracker
+- Priority: `P1`
+- Goal: close or rename stale open milestones with zero open issues
+- References:
+  - [tracker-refresh-drafts.md](/Users/jess/git/cmux/docs/tracker-refresh-drafts.md:250)
+- Exit criteria:
+  - `M6` through `M9` are no longer misleadingly open
+  - `M12` remains the active distro-testing milestone
+
+## Lane 2: KVM And Release Artifact QA
+
+### KVM-001 Verify Current Release-Gated VM Matrix
+
+- Type: KVM/package QA
+- Priority: `P0`
+- Environment: self-hosted KVM runner
+- Goal: keep current release-gated VM validation stable
+- Distros:
+  - `Ubuntu 24.04`
+  - `Debian 12`
+  - `Rocky 9` RPM proxy
+- References:
+  - [test-distro.yml](/Users/jess/git/cmux/.github/workflows/test-distro.yml:42)
+  - [release-linux.yml](/Users/jess/git/cmux/.github/workflows/release-linux.yml:309)
+- Evidence:
+  - package install success
+  - `ldd` output with no unresolved libraries
+  - binary launch proof
+- Exit criteria:
+  - current KVM matrix passes on the exact release artifacts under test
+
+### KVM-002 Fedora 42 VM Harness Decision
+
+- Type: infra/QA design
+- Priority: `P0`
+- Goal: decide how to get fresh-install proof for `Fedora 42`
+- Current blocker:
+  - upstream `nix-vm-test` currently tops out at Fedora 41
+- References:
+  - [nix/tests-distro.nix](/Users/jess/git/cmux/nix/tests-distro.nix:156)
+  - [linux-packaging-cd-plan.md](/Users/jess/git/cmux/docs/linux-packaging-cd-plan.md:234)
+- Exit criteria:
+  - selected approach for Fedora 42 fresh-install validation
+
+### KVM-003 Rocky 10 VM Harness Decision
+
+- Type: infra/QA design
+- Priority: `P0`
+- Goal: decide how to get fresh-install proof for `Rocky 10`
+- Current blocker:
+  - upstream `nix-vm-test` currently tops out at Rocky 9.6
+- References:
+  - [nix/tests-distro.nix](/Users/jess/git/cmux/nix/tests-distro.nix:156)
+  - [linux-validation-checklist.md](/Users/jess/git/cmux/docs/linux-validation-checklist.md:214)
+- Exit criteria:
+  - selected approach for Rocky 10 fresh-install validation
+
+### KVM-004 Artifact Taxonomy Review
+
+- Type: packaging QA
+- Priority: `P1`
+- Goal: decide whether current Linux artifacts map cleanly to support tiers
+- Questions:
+  - should Debian consume the broad-feature `DEB`?
+  - does Debian need a baseline/no-WebKit artifact?
+  - does Rocky stay terminal-first via RPM only?
+  - does Flatpak become the cross-distro broad-feature channel?
+- References:
+  - [linux-packaging-cd-plan.md](/Users/jess/git/cmux/docs/linux-packaging-cd-plan.md:102)
+- Exit criteria:
+  - one explicit artifact taxonomy decision recorded
+
+## Lane 3: Direct Linux Distro QA
+
+### QA-UBU-001 Ubuntu 24.04 Broad-Feature QA
+
+- Type: direct VM/host QA
+- Priority: `P0`
+- Distro: `Ubuntu 24.04`
+- Goal: establish one clean Tier A broad-feature proof pass
+- Checklist:
+  - install release `DEB`
+  - launch app
+  - verify terminal/split smoke
+  - verify socket/API smoke
+  - open browser panel
+  - navigate and query current URL
+  - use browser find
+  - open and close devtools
+  - verify notification delivery
+  - verify lock/unlock does not break terminal state
+- References:
+  - [linux-validation-checklist.md](/Users/jess/git/cmux/docs/linux-validation-checklist.md:19)
+- Exit criteria:
+  - pass or one crisp blocker with evidence
+
+### QA-FED-001 Fedora 42 Broad-Feature QA
+
+- Type: direct VM/host QA
+- Priority: `P0`
+- Distro: `Fedora 42`
+- Goal: establish one clean Tier A broad-feature proof pass
+- Checklist:
+  - install release `RPM`
+  - launch app
+  - verify terminal/split smoke
+  - verify socket/API smoke
+  - browser open/navigate/find/devtools
+  - notification delivery
+  - lock/unlock behavior
+- References:
+  - [linux-validation-checklist.md](/Users/jess/git/cmux/docs/linux-validation-checklist.md:19)
+- Exit criteria:
+  - pass or one crisp blocker with evidence
+
+### QA-DEB-001 Debian 12 Baseline QA
+
+- Type: direct VM/host QA
+- Priority: `P0`
+- Distro: `Debian 12`
+- Goal: prove the baseline story and record browser status explicitly
+- Checklist:
+  - install release `DEB`
+  - launch app
+  - verify terminal baseline
+  - verify split/focus baseline
+  - verify basic socket/API baseline
+  - record browser status explicitly
+  - record WebAuthn status explicitly
+- References:
+  - [linux-validation-checklist.md](/Users/jess/git/cmux/docs/linux-validation-checklist.md:83)
+- Exit criteria:
+  - Debian is no longer implicitly treated as full-feature
+
+### QA-RKY-001 Rocky 10 Terminal-First QA
+
+- Type: direct VM/host QA
+- Priority: `P0`
+- Distro: `Rocky 10`
+- Goal: prove the constrained terminal-first story directly
+- Checklist:
+  - install package or validated runtime artifact
+  - launch app
+  - verify terminal/split/focus smoke
+  - verify socket/API baseline
+  - verify session file path behavior
+  - if `-Dno-webkit`, verify browser commands fail clearly
+- References:
+  - [linux-validation-checklist.md](/Users/jess/git/cmux/docs/linux-validation-checklist.md:114)
+  - [linux-parity-matrix.md](/Users/jess/git/cmux/docs/linux-parity-matrix.md:52)
+- Exit criteria:
+  - Rocky 10 has explicit terminal-first proof
+
+## Lane 4: Linux Parity Implementation Work
+
+### PAR-001 Linux WebAuthn Bridge Completion
+
+- Type: implementation
+- Priority: `P0`
+- Goal: move Linux WebAuthn from installed-stub to end-to-end implementation
+- References:
+  - [browser.zig](/Users/jess/git/cmux/cmux-linux/src/browser.zig:105)
+  - [webauthn_bridge.zig](/Users/jess/git/cmux/cmux-linux/src/webauthn_bridge.zig:61)
+  - [tracker-refresh-drafts.md](/Users/jess/git/cmux/docs/tracker-refresh-drafts.md:129)
+- Scope:
+  - parse bridge request
+  - dispatch to CTAP2 path
+  - reply to JavaScript
+  - run one real ceremony on a Tier A distro
+- Exit criteria:
+  - parity docs can move WebAuthn above `unsupported`
+
+### PAR-002 Linux Socket / Control Plane Parity
+
+- Type: implementation
+- Priority: `P0`
+- Goal: close the highest-value Linux control-plane stubs
+- References:
+  - [socket.zig](/Users/jess/git/cmux/cmux-linux/src/socket.zig:957)
+  - [socket.zig](/Users/jess/git/cmux/cmux-linux/src/socket.zig:1120)
+  - [app.zig](/Users/jess/git/cmux/cmux-linux/src/app.zig:11)
+  - [tracker-refresh-drafts.md](/Users/jess/git/cmux/docs/tracker-refresh-drafts.md:162)
+- Scope:
+  - `surface.send_text`
+  - `surface.read_text`
+  - `pane.break`
+  - `pane.join`
+  - `surface.move`
+  - `surface.reorder`
+  - action/clipboard callbacks
+- Exit criteria:
+  - high-value gaps are implemented or explicitly downgraded in docs
+
+### PAR-003 Linux Restore And Headless Runtime
+
+- Type: implementation / scoping
+- Priority: `P1`
+- Goal: decide and implement the next honest step for restore and `cmux-term`
+- References:
+  - [session.zig](/Users/jess/git/cmux/cmux-linux/src/session.zig:221)
+  - [main_headless.zig](/Users/jess/git/cmux/cmux-linux/src/main_headless.zig:23)
+  - [tracker-refresh-drafts.md](/Users/jess/git/cmux/docs/tracker-refresh-drafts.md:198)
+- Exit criteria:
+  - both surfaces have explicit supported-state language and a realistic next step
+
+## Lane 5: Participating Libraries And Dependency QA
+
+### LIB-001 Ghostty Ingestion Watchlist
+
+- Type: dependency hygiene
+- Priority: `P1`
+- Goal: keep `ghostty` visible as the only major carried ingestion-risk dependency
+- Current read:
+  - pin ancestry is healthy
+  - still meaningfully ahead and behind upstream
+- References:
+  - [component-portfolio.md](/Users/jess/git/cmux/docs/component-portfolio.md:90)
+  - [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:33)
+- Exit criteria:
+  - current carried patch set remains documented and tractable
+
+### LIB-002 Bonsplit Delta Audit
+
+- Type: dependency hygiene
+- Priority: `P2`
+- Goal: confirm whether any minimal fork-only `bonsplit` delta remains worth
+  isolating
+- References:
+  - [component-portfolio.md](/Users/jess/git/cmux/docs/component-portfolio.md:97)
+  - [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:39)
+- Exit criteria:
+  - minimal delta recorded as either maintenance-only or candidate slice
+
+### LIB-003 zig-ctap2 Linux Hidraw QA
+
+- Type: library QA
+- Priority: `P1`
+- Goal: prove the Linux CTAP2 path on a real distro and hardware-backed flow
+- Current note:
+  - `zig-ctap2` already has an open Linux hidraw end-to-end testing issue
+- Exit criteria:
+  - one recorded Linux hidraw test result and blocker list if needed
+
+### LIB-004 zig-keychain Distro Secret-Service QA
+
+- Type: library QA
+- Priority: `P1`
+- Goal: validate Secret Service behavior on supported Linux distros
+- Focus:
+  - Ubuntu 24.04
+  - Fedora 42
+  - Debian 12 status if practical
+- Exit criteria:
+  - libsecret behavior is recorded for the distros that matter
+
+### LIB-005 zig-notify Desktop Delivery QA
+
+- Type: library QA
+- Priority: `P1`
+- Goal: validate notification delivery in the current GNOME/Wayland target path
+- Exit criteria:
+  - one recorded notification proof path on a Tier A distro
+
+### LIB-006 Homebrew Sync Hygiene
+
+- Type: packaging hygiene
+- Priority: `P3`
+- Goal: resync `homebrew-cmux` when doing the next release hygiene pass
+- Exit criteria:
+  - tracked only; not allowed to displace Linux QA work
+
+## Lane 6: Upstream-Prep Candidates
+
+These are not submission tasks. They are local preparation tasks only.
+
+### UPL-001 Ghostty OSC 99 Candidate Slice
+
+- Type: candidate prep
+- Priority: `P2`
+- Goal: keep the OSC 99 notification parser slice documented and reviewable
+- Reference:
+  - [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:35)
+
+### UPL-002 Ghostty Display-Link Candidate Slice
+
+- Type: candidate prep
+- Priority: `P2`
+- Goal: keep the macOS display-link restart fix isolated and documented
+- Reference:
+  - [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:36)
+
+### UPL-003 Standalone Zig Library Polish
+
+- Type: candidate prep
+- Priority: `P2`
+- Goal: keep `zig-ctap2`, `zig-keychain`, and `zig-crypto` in a state where
+  packaging/docs polish can be submitted manually later
+- Reference:
+  - [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:40)
+
+## Lane 7: Reintegration / RFC Futures
+
+### FUT-001 cmux vs lmux Naming Decision
+
+- Type: RFC / product
+- Priority: `P3`
+- Goal: keep the naming decision visible without letting it block Linux proof
+- References:
+  - [Issue #76](https://github.com/Jesssullivan/cmux/issues/76)
+  - [linux-work-week-2026-04-14.md](/Users/jess/git/cmux/docs/linux-work-week-2026-04-14.md:1)
+- Exit criteria:
+  - decision deferred until parity and distro proof are stronger
+
+### FUT-002 Reintegration / Proposal Readiness
+
+- Type: strategy
+- Priority: `P3`
+- Goal: keep a future path open for manaflow reintegration proposals once Linux
+  proof is stronger
+- Questions:
+  - which Linux deltas are fork-only?
+  - which are reintegration candidates?
+  - which participating libraries are mature enough to present as stable
+    building blocks?
+- Exit criteria:
+  - strategy questions are documented without forcing premature proposal work
+
+## Recommended First Shards For The Week
+
+If the goal is a productive parallel week, start here:
+
+1. `GOV-001` merge `#205`
+2. `GOV-002` refresh `#55`
+3. `GOV-003` refresh `#187`
+4. `QA-UBU-001` Ubuntu 24.04 broad-feature QA
+5. `QA-FED-001` Fedora 42 broad-feature QA
+6. `QA-DEB-001` Debian 12 baseline QA
+7. `QA-RKY-001` Rocky 10 terminal-first QA
+8. `KVM-002` Fedora 42 VM harness decision
+9. `KVM-003` Rocky 10 VM harness decision
+10. `PAR-001` and `PAR-002` as the next implementation lanes after QA results land

--- a/docs/linux-program-plan.md
+++ b/docs/linux-program-plan.md
@@ -6,6 +6,8 @@ execution program.
 Short current-state readout:
 - `docs/program-status.md`
 - `docs/linux-packaging-cd-plan.md`
+- `docs/linux-work-week-2026-04-14.md`
+- `docs/linear-qa-shard-punchlist.md`
 
 The goal is straightforward:
 
@@ -20,6 +22,14 @@ Deliver a native Linux `cmux` that is:
 - feature-complete on the main supported desktop distros
 - explicit about constrained-distro limitations
 - backed by repeatable packaging and CI validation
+
+## Current Execution Surface
+
+For the current work week, use these as the active execution docs:
+
+- [linux-work-week-2026-04-14.md](/Users/jess/git/cmux/docs/linux-work-week-2026-04-14.md:1)
+- [linear-qa-shard-punchlist.md](/Users/jess/git/cmux/docs/linear-qa-shard-punchlist.md:1)
+- [program-review-2026-04-14.md](/Users/jess/git/cmux/docs/program-review-2026-04-14.md:1)
 
 ## Support Tiers
 

--- a/docs/linux-work-week-2026-04-14.md
+++ b/docs/linux-work-week-2026-04-14.md
@@ -1,0 +1,227 @@
+# Linux Work Week Plan
+
+This document is the week-scale execution plan for the Linux-native `cmux`
+program as of `2026-04-14`.
+
+Use it with:
+
+- [program-status.md](/Users/jess/git/cmux/docs/program-status.md:1)
+- [program-review-2026-04-14.md](/Users/jess/git/cmux/docs/program-review-2026-04-14.md:1)
+- [linux-program-plan.md](/Users/jess/git/cmux/docs/linux-program-plan.md:1)
+- [linear-qa-shard-punchlist.md](/Users/jess/git/cmux/docs/linear-qa-shard-punchlist.md:1)
+
+## North Star
+
+Ship Linux-native `cmux` with explicit distro support tiers, truthful package
+metadata, repeatable fresh-install proof, and a parity surface that reflects
+what actually works today rather than what merely has source files.
+
+## Current Read
+
+The broad shape is good.
+
+- `cmux` repo health is good
+- hosted Linux CI is green
+- KVM package validation is real and release-gating
+- dependency hygiene is mostly healthy
+
+The main work has shifted from architecture to proof and scope control.
+
+## This Week's Priority Order
+
+### 1. Merge And Stabilize `#205`
+
+Why first:
+
+- it already contains the hygiene, packaging, distro-test, and status work the
+  program should build on
+- it materially improves the release surface and the public state of the repo
+
+Success:
+
+- `#205` merged
+- no new Linux CI regressions introduced immediately after merge
+
+### 2. Refresh The Public Planning Surface
+
+Why next:
+
+- the current repo docs are more accurate than the current public issue and
+  milestone bodies
+- stale tracker state is now a coordination risk
+
+Scope:
+
+- refresh `#55`
+- refresh `#187`
+- refresh `#199`
+- keep `#76` explicitly non-blocking
+- keep `#201` explicitly parallel
+- clean up stale open milestones `M6` through `M9`
+
+Success:
+
+- the public tracker matches the current code and distro support reality
+
+### 3. Run Direct Tier A QA
+
+Why now:
+
+- the remaining blocker is not build breakage, it is proving real user-facing
+  behavior on real distros
+
+Scope:
+
+- `Ubuntu 24.04` direct feature QA
+- `Fedora 42` direct feature QA
+
+Focus:
+
+- package install
+- runtime launch
+- terminal/split smoke
+- socket/API smoke
+- browser smoke
+- desktop integration smoke
+
+Success:
+
+- one recorded proof pass or one crisp blocker per distro
+
+### 4. Close The Debian And Rocky Truth Gaps
+
+Why this matters:
+
+- Debian is currently a baseline distro, not yet a broad-feature claim
+- Rocky 10 is currently terminal-first, not browser-first
+
+Scope:
+
+- record Debian 12 browser/WebAuthn status explicitly
+- run direct Rocky 10 terminal-first QA
+- make package/runtime limits explicit where needed
+
+Success:
+
+- Debian is accurately classified
+- Rocky is accurately classified
+
+### 5. Decide The Next VM Harness Move
+
+Why this matters:
+
+- KVM release-gated proof exists, but the current VM matrix still does not cover
+  `Fedora 42` or `Rocky 10`
+
+Decision to make:
+
+1. extend `nix-vm-test` coverage when upstream images exist
+2. carry a local harness extension
+3. add an alternate VM path for those distros
+
+Success:
+
+- one selected approach for `Fedora 42` and `Rocky 10` fresh-install proof
+
+### 6. Split The Remaining Linux Parity Work Into Dedicated Lanes
+
+Why this matters:
+
+- WebAuthn, socket/control-plane parity, and restore/headless are currently
+  buried under the Linux umbrella
+
+Dedicated lanes:
+
+- Linux WebAuthn bridge completion
+- Linux socket/control-plane parity
+- Linux session restore and headless runtime
+
+Success:
+
+- each lane has a clear scope, references, and exit criteria
+
+### 7. Keep Upstream-Prep Parallel And Small
+
+Why this matters:
+
+- there are good small extraction candidates, but they should not disrupt Linux
+  delivery
+
+Good candidates:
+
+- `ghostty` OSC 99 notification parser
+- `ghostty` display-link restart fix
+- minimal `bonsplit` fork delta
+- standalone Zig library docs/packaging polish
+
+Success:
+
+- candidate slices stay visible without becoming the critical path
+
+## Parallel Work Lanes
+
+### Lane A: Repo Governance And Planning
+
+Scope:
+
+- merge `#205`
+- tracker refresh
+- milestone cleanup
+- roadmap/status doc upkeep
+
+### Lane B: KVM And Packaging Proof
+
+Scope:
+
+- current release-gated distro VM validation
+- artifact taxonomy review
+- exact-artifact validation discipline
+- Fedora 42 / Rocky 10 harness strategy
+
+### Lane C: Direct Linux QA
+
+Scope:
+
+- Ubuntu 24.04
+- Fedora 42
+- Debian 12
+- Rocky 10
+
+### Lane D: Linux Parity Implementation
+
+Scope:
+
+- WebAuthn bridge completion
+- socket/control-plane completion
+- restore/headless decisions and implementation
+
+### Lane E: Dependency And Upstream-Prep Hygiene
+
+Scope:
+
+- `ghostty` watchlist
+- `bonsplit` low-delta review
+- `zig-ctap2`, `zig-keychain`, `zig-crypto`, `zig-notify` status checks
+- small extraction candidates only
+
+## Work Week Decision Rules
+
+1. Do not open new architecture lanes until direct distro QA produces either
+   proof or crisp blockers.
+2. Do not promote a Linux feature based on source presence alone.
+3. Do not let upstream-prep work outrun Linux delivery work.
+4. Do not distort repo ownership or cache policy to satisfy builder tooling.
+5. Treat Rocky 10 as terminal-first until proven otherwise in a real packaging
+   path.
+
+## End-Of-Week Desired Output
+
+The week is successful if these are true:
+
+1. `#205` is merged
+2. public issues and milestones reflect current reality
+3. direct QA results exist for `Ubuntu 24.04` and `Fedora 42`
+4. Debian 12 browser status is explicitly recorded
+5. Rocky 10 terminal-first status is explicitly recorded
+6. the next VM-harness decision for `Fedora 42` and `Rocky 10` is made
+7. the remaining parity gaps are split into dedicated work items

--- a/docs/program-review-2026-04-14.md
+++ b/docs/program-review-2026-04-14.md
@@ -1,0 +1,422 @@
+# Program Review And QA Punchlist
+
+This document is a time-boxed program review for the native Linux `cmux`
+initiative as of `2026-04-14`.
+
+It is intentionally practical. The goal is to answer:
+
+1. what is actually healthy
+2. what is still incomplete
+3. what must be tested next on real Linux VMs and hosts
+4. which upstream-prep slices are worth isolating without putting them on the
+   current Linux critical path
+
+This review does not authorize external submission work.
+
+- agents may identify, isolate, document, and test candidate slices
+- agents do not contact upstreams or non-`Jesssullivan` / non-`tinyland-inc`
+  repos
+- manual upstream correspondence remains with Jess
+
+Execution follow-up:
+
+- [linux-work-week-2026-04-14.md](/Users/jess/git/cmux/docs/linux-work-week-2026-04-14.md:1)
+- [linear-qa-shard-punchlist.md](/Users/jess/git/cmux/docs/linear-qa-shard-punchlist.md:1)
+
+## Executive Readout
+
+The project is in a stronger state than the public tracker suggests.
+
+- `cmux` itself is healthy and current versus `upstream/main`
+- Linux CI is green across the hosted container/build matrix
+- fresh-install KVM package validation is real and now gates Linux release upload
+- dependency hygiene is mostly clean
+- `ghostty` is the only major carried dependency with meaningful upstream
+  ingestion pressure
+
+The main blocker has shifted.
+
+- the blocker is no longer “can native Linux cmux build?”
+- the blocker is “can the project prove the right capability level on the right
+  distros without overstating what is finished?”
+
+## Current Reality
+
+### Repo and dependency health
+
+- `cmux` is ahead of `upstream/main` and not behind it
+- `ghostty` fork ancestry is repaired and the checked-in pin is reachable from
+  fork `main`
+- `ghostty` remains the largest carried delta and the main upstream-ingestion
+  watchlist
+- `vendor/bonsplit`, `vendor/ctap2`, `vendor/zig-crypto`,
+  `vendor/zig-keychain`, and `vendor/zig-notify` are all currently healthy from
+  a pin/ancestry perspective
+- `homebrew-cmux` is slightly behind its tracked upstream and is packaging debt,
+  not a Linux blocker
+
+Primary references:
+
+- [component-portfolio.md](/Users/jess/git/cmux/docs/component-portfolio.md:18)
+- [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:31)
+- [ghostty-fork.md](/Users/jess/git/cmux/docs/ghostty-fork.md:1)
+
+### CI, builder, and cache posture
+
+- `Jesssullivan/cmux` intentionally stays on Magic Nix Cache
+- `tinyland-inc/lab` remains the FlakeHub-heavy org-owned builder lane
+- Linux hosted CI is green across `Ubuntu 24.04`, `Fedora 42`, `Rocky 10`,
+  `Debian 12` baseline, `Arch`, and the Linux vendor-library lane
+- self-hosted KVM package-install tests currently cover `Ubuntu 24.04`,
+  `Debian 12`, and `Rocky 9` as an RPM-path proxy
+- tagged Linux releases now validate the just-built `DEB` and `RPM` artifacts in
+  fresh distro VMs before Linux upload
+
+Primary references:
+
+- [program-status.md](/Users/jess/git/cmux/docs/program-status.md:99)
+- [linux-packaging-cd-plan.md](/Users/jess/git/cmux/docs/linux-packaging-cd-plan.md:13)
+- [test-distro.yml](/Users/jess/git/cmux/.github/workflows/test-distro.yml:1)
+- [release-linux.yml](/Users/jess/git/cmux/.github/workflows/release-linux.yml:309)
+
+### KVM / distro-test reality
+
+Current KVM package-install validation is real, but not complete.
+
+What is working:
+
+- exact release artifact validation can be run from a release tag
+- the checked-in manifest path is now replaceable by an exact release override
+- Linux release upload waits for self-hosted distro validation
+- post-install linker resolution is checked with `ldd`
+
+What is not complete:
+
+- KVM tests do not run on untrusted PRs by design
+- KVM coverage still stops at `Ubuntu 24.04`, `Debian 12`, and `Rocky 9` proxy
+- `Fedora 42` and `Rocky 10` VM package-install proof are still blocked by
+  upstream `nix-vm-test` image coverage, not by repo-local indecision
+
+Primary references:
+
+- [nix/tests-distro.nix](/Users/jess/git/cmux/nix/tests-distro.nix:1)
+- [test-distro.yml](/Users/jess/git/cmux/.github/workflows/test-distro.yml:3)
+
+## Actual Linux Parity State
+
+### Implemented enough to validate
+
+- terminal surfaces and split tree are real enough to validate on live distros
+- browser panel support exists on WebKit-capable builds
+- notifications and logind integration exist in meaningful part
+- Linux socket/API exists in meaningful part
+
+These lanes need proof more than architecture work.
+
+Primary reference:
+
+- [linux-parity-matrix.md](/Users/jess/git/cmux/docs/linux-parity-matrix.md:18)
+
+### Not ready for promotion
+
+These are the surfaces that still need explicit downgrade language and focused
+follow-up work:
+
+1. WebAuthn bridge
+   The browser panel installs the bridge, but the native handler is still a
+   stub. `onScriptMessage` still contains only `TODO`s and a log line.
+
+   References:
+   - [browser.zig](/Users/jess/git/cmux/cmux-linux/src/browser.zig:105)
+   - [webauthn_bridge.zig](/Users/jess/git/cmux/cmux-linux/src/webauthn_bridge.zig:61)
+
+2. Socket/control-plane parity
+   `surface.send_text`, `surface.read_text`, `pane.break`, `pane.join`,
+   `surface.move`, and `surface.reorder` are still placeholders or success-only
+   stubs. Linux host callbacks for libghostty actions and clipboard are also
+   mostly no-op.
+
+   References:
+   - [socket.zig](/Users/jess/git/cmux/cmux-linux/src/socket.zig:957)
+   - [socket.zig](/Users/jess/git/cmux/cmux-linux/src/socket.zig:1120)
+   - [socket.zig](/Users/jess/git/cmux/cmux-linux/src/socket.zig:1171)
+   - [app.zig](/Users/jess/git/cmux/cmux-linux/src/app.zig:11)
+
+3. Session restore
+   Save-path scaffolding exists, but restore still returns `false`.
+
+   Reference:
+   - [session.zig](/Users/jess/git/cmux/cmux-linux/src/session.zig:221)
+
+4. Headless/server mode
+   `cmux-term` is still placeholder-only and does not yet initialize a real
+   headless terminal runtime.
+
+   Reference:
+   - [main_headless.zig](/Users/jess/git/cmux/cmux-linux/src/main_headless.zig:23)
+
+## Tracker And Milestone Reality
+
+The planning surface is smaller than the open milestone list makes it look.
+
+### Open issues that still matter
+
+- `#55` `Epic: De-Attestation & Linux Porting Roadmap`
+- `#76` `RFC: Linux client naming — cmux vs lmux`
+- `#187` `ci(distro): Rocky 10 — track upstream nix-vm-test support`
+- `#199` `audit: fork landscape, novel libraries, and upstream PR opportunities`
+- `#201` `feat(cmuxd-remote): add TCP listener mode for Tailnet direct connections`
+
+### Tracker problems
+
+1. `#55` is stale
+   It still reads like an early Linux MVP roadmap and still treats many current
+   capabilities as future milestone items rather than implemented-but-unproven
+   surfaces.
+
+2. `#187` is stale
+   It still says Rocky 10 has not been released yet, which is no longer true.
+   The real blocker is upstream `nix-vm-test` coverage, not distro availability.
+
+3. `#199` is stale in divergence numbers and still includes manual-upstream
+   action items that should remain outside agent scope.
+
+4. `#76` is a valid RFC, but it is non-blocking and should stay that way.
+
+5. `#201` is a real future lane, but it is not on the Linux packaging/parity
+   critical path.
+
+### Milestone problems
+
+Only one open milestone still has live open work.
+
+- `M12 — QEMU Distro Testing` is the only open milestone with open issues
+- `M6`, `M7`, `M8`, and `M9` are still open with `0` open issues each
+
+Operational interpretation:
+
+- milestone closure and renaming are now repo hygiene tasks
+- the active milestone in practice is the distro-testing lane
+
+## Participating Library Review
+
+### `ghostty`
+
+Current read:
+
+- highest-churn carried dependency
+- current pin is healthy from a fork-ancestry perspective
+- still materially behind upstream while carrying meaningful local work
+
+This is the only participating library that should stay on the active
+ingestion-risk watchlist.
+
+### `vendor/bonsplit`
+
+Current read:
+
+- low-delta
+- effectively maintenance-level
+- worth isolating only if a very small fork-only delta remains
+
+### `vendor/ctap2`
+
+Current read:
+
+- repo hygiene is healthy
+- standalone issue tracker already shows Linux transport/testing still matters
+- the open item that matters most here is Linux hidraw end-to-end testing
+
+### `vendor/zig-keychain`
+
+Current read:
+
+- repo hygiene is healthy
+- remaining work is distro/runtime proof, not repo rescue
+
+### `vendor/zig-crypto`
+
+Current read:
+
+- healthy and not on the critical path
+
+### `vendor/zig-notify`
+
+Current read:
+
+- healthy
+- remaining work is real notification proof on Linux desktops
+
+### `homebrew-cmux`
+
+Current read:
+
+- minor sync debt only
+- not relevant to the Linux proof critical path
+
+## RFC / Upstream-Prep Opportunities
+
+These should be kept deliberately small and parallel to Linux delivery.
+
+### Best small-slice candidates
+
+1. `ghostty`: OSC 99 notification parser
+2. `ghostty`: macOS display-link restart fix
+3. `vendor/bonsplit`: any remaining minimal fork delta after sync
+4. `vendor/zig-ctap2`, `vendor/zig-keychain`, `vendor/zig-crypto`:
+   packaging/docs polish as standalone library work
+
+Primary reference:
+
+- [upstream-candidate-ledger.md](/Users/jess/git/cmux/docs/upstream-candidate-ledger.md:31)
+
+### Not good extraction candidates right now
+
+- Linux WebAuthn bridge work
+- Linux socket/control-plane parity work
+- session restore and headless runtime work
+- distro-testing harness changes tightly coupled to current release automation
+
+These are still on the product critical path and should not be decomposed for
+manual submission before they stabilize.
+
+## QA Punchlist
+
+### A. KVM / package-install punchlist
+
+1. Keep the current release-gated KVM path stable on:
+   - `Ubuntu 24.04`
+   - `Debian 12`
+   - `Rocky 9` RPM proxy
+2. Add exact-artifact validation as the standard pre-release confidence path for
+   every Linux tag.
+3. Decide whether to extend the current harness or add a second VM path for:
+   - `Fedora 42`
+   - `Rocky 10`
+4. Retire `Rocky 9` as the proxy once `Rocky 10` fresh-install proof exists.
+5. Decide whether Debian should keep consuming the broad-feature `DEB` or needs
+   an explicit baseline/no-WebKit artifact.
+
+### B. Direct VM feature QA punchlist
+
+Run these on fresh VMs or real distro hosts and record outcomes explicitly.
+
+#### Ubuntu 24.04
+
+- install release `DEB`
+- launch app
+- verify terminal/split smoke
+- verify socket baseline
+- verify browser open/navigate/focus/find/devtools
+- verify notification delivery
+- verify lock/unlock does not break terminal state
+- verify current session-restore behavior matches documented `partial`
+
+#### Fedora 42
+
+- install release `RPM`
+- launch app
+- verify terminal/split smoke
+- verify socket baseline
+- verify browser open/navigate/focus/find/devtools
+- verify notification delivery
+- verify lock/unlock behavior
+
+#### Debian 12
+
+- install release `DEB`
+- launch app
+- verify terminal and socket baseline
+- record browser/WebAuthn status explicitly instead of assuming parity
+
+#### Rocky 10
+
+- validate terminal-first path directly
+- verify package/runtime path
+- verify splits/focus/socket baseline
+- verify browser commands fail clearly if `-Dno-webkit`
+- record whether Flatpak becomes the only practical broad-feature path
+
+### C. Parity implementation punchlist
+
+1. Finish Linux WebAuthn bridge request handling:
+   - parse message
+   - dispatch CTAP2 work
+   - reply to JavaScript
+   - prove one real hardware-backed ceremony on a Tier A distro
+2. Implement real Linux control-plane gaps:
+   - `surface.send_text`
+   - `surface.read_text`
+   - `pane.break`
+   - `pane.join`
+   - `surface.move`
+   - `surface.reorder`
+   - host action/clipboard callbacks
+3. Either implement Linux restore enough to promote it, or keep the docs and
+   release metadata conservative
+4. Either implement `cmux-term` enough to promote it to `partial`, or keep it
+   clearly out of release claims
+
+### D. Tracker / milestone punchlist
+
+1. Rewrite `#55` as the current Linux umbrella:
+   - distro proof
+   - package taxonomy
+   - parity gaps
+   - feature QA
+2. Refresh `#187` to say:
+   - Rocky 10 is GA
+   - blocker is upstream `nix-vm-test`
+   - Rocky 9 is current RPM-path proxy only
+3. Refresh `#199` so it reflects current divergence and manual-upstream policy
+4. Keep `#76` explicitly non-blocking
+5. Keep `#201` separate from Linux distro delivery
+6. Close, rename, or archive stale open milestones with zero open issues:
+   - `M6`
+   - `M7`
+   - `M8`
+   - `M9`
+
+### E. Reintegration / future proposal punchlist
+
+This is not a current delivery blocker, but it is worth structuring now.
+
+Questions to settle after Linux proof is stronger:
+
+1. When does “Linux native cmux” become strong enough to justify a
+   `cmux`/`lmux` naming decision?
+2. Which Linux deltas are fork-only versus reintegration candidates?
+3. Which participating libraries are mature enough to be treated as stable
+   external building blocks?
+4. Which carried behaviors in `ghostty` or `bonsplit` should stay local until
+   the Linux product surface itself settles?
+
+## Recommended Near-Term Sequence
+
+1. Merge `#205`
+2. Refresh tracker issue bodies and stale milestones
+3. Run direct VM feature QA on `Ubuntu 24.04` and `Fedora 42`
+4. Record explicit Debian 12 browser status
+5. Decide how to get fresh-install proof for `Fedora 42` and `Rocky 10`
+6. Open or isolate dedicated work items for:
+   - Linux WebAuthn bridge completion
+   - Linux socket/control-plane parity
+   - Linux restore/headless runtime
+7. Keep upstream-prep work parallel and small; do not let it displace distro
+   proof
+
+## Bottom Line
+
+The program is in a credible delivery phase.
+
+- repo hygiene is broadly good
+- package/build CI is broadly good
+- KVM distro validation is real
+- the carried library graph is mostly healthy
+
+The remaining work is now mostly about truth, proof, and scope control:
+
+- truthful parity language
+- fresh-install proof on the intended distros
+- direct feature QA on real VMs and hosts
+- small, disciplined upstream-prep slices that do not disrupt Linux delivery

--- a/docs/program-status.md
+++ b/docs/program-status.md
@@ -11,6 +11,9 @@ It complements, rather than replaces:
 - `docs/linux-program-plan.md`
 - `docs/linux-packaging-cd-plan.md`
 - `docs/linux-parity-matrix.md`
+- `docs/linux-work-week-2026-04-14.md`
+- `docs/linear-qa-shard-punchlist.md`
+- `docs/program-review-2026-04-14.md`
 - `docs/linux-validation-checklist.md`
 - `docs/tracker-refresh-notes.md`
 


### PR DESCRIPTION
## Summary
- add a week-scale Linux work plan
- add a Linear-ready QA shard punchlist for distro, KVM, parity, and participating library work
- link the new execution docs from the active status and program-plan surfaces

## Notes
- docs only
- no local tests run
- external upstream repos were not touched