### PR TITLE
ci(release-linux): GPG-sign DEB, RPM, and tarball release artifacts

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -193,17 +193,30 @@ jobs:
           tar czf "cmux-${VERSION}-linux-${TAR_ARCH}.tar.gz" "${STAGING}"
           echo "Built: cmux-${VERSION}-linux-${TAR_ARCH}.tar.gz ($(du -h "cmux-${VERSION}-linux-${TAR_ARCH}.tar.gz" | cut -f1))"
 
+      - name: Sign DEB and tarball with GPG
+        env:
+          LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          LINUX_GPG_PASSPHRASE: ${{ secrets.LINUX_GPG_PASSPHRASE }}
+          LINUX_GPG_KEY_ID: ${{ secrets.LINUX_GPG_KEY_ID }}
+        run: bash scripts/sign-linux-packages.sh
+
       - name: Upload DEB artifact
         uses: actions/upload-artifact@v4
         with:
           name: cmux-linux-deb-${{ matrix.arch.deb }}
-          path: cmux_*_${{ matrix.arch.deb }}.deb
+          path: |
+            cmux_*_${{ matrix.arch.deb }}.deb
+            cmux_*_${{ matrix.arch.deb }}.deb.asc
+          if-no-files-found: error
 
       - name: Upload tarball artifact
         uses: actions/upload-artifact@v4
         with:
           name: cmux-linux-tarball-${{ matrix.arch.tar }}
-          path: cmux-*-linux-${{ matrix.arch.tar }}.tar.gz
+          path: |
+            cmux-*-linux-${{ matrix.arch.tar }}.tar.gz
+            cmux-*-linux-${{ matrix.arch.tar }}.tar.gz.asc
+          if-no-files-found: error
 
   # ── Build + package on Fedora (RPM) ──────────────────────────────
   build-rpm:
@@ -221,7 +234,7 @@ jobs:
       - name: Install build dependencies
         run: |
           dnf install -y \
-            git rpm-build systemd-rpm-macros \
+            git rpm-build rpm-sign gnupg2 systemd-rpm-macros \
             gcc gcc-c++ pkg-config \
             gtk4-devel libadwaita-devel \
             webkitgtk6.0-devel \
@@ -325,11 +338,21 @@ jobs:
           RPM_NAME=$(basename "$RPM")
           echo "Built: $RPM_NAME ($(du -h "$RPM_NAME" | cut -f1))"
 
+      - name: Sign RPM with GPG
+        env:
+          LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          LINUX_GPG_PASSPHRASE: ${{ secrets.LINUX_GPG_PASSPHRASE }}
+          LINUX_GPG_KEY_ID: ${{ secrets.LINUX_GPG_KEY_ID }}
+        run: bash scripts/sign-linux-packages.sh
+
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4
         with:
           name: cmux-linux-rpm-${{ matrix.arch.rpm }}
-          path: cmux-*.${{ matrix.arch.rpm }}.rpm
+          path: |
+            cmux-*.${{ matrix.arch.rpm }}.rpm
+            cmux-*.${{ matrix.arch.rpm }}.rpm.asc
+          if-no-files-found: error
 
   validate-distro-install:
     name: Validate Linux packages in distro VMs
@@ -451,7 +474,11 @@ jobs:
           ASSETS=()
           # Each matrix leg uploads to its own arch-suffixed artifact dir
           # (e.g. cmux-linux-deb-amd64/, cmux-linux-rpm-aarch64/).
-          for f in cmux-linux-deb-*/*.deb cmux-linux-rpm-*/*.rpm cmux-linux-tarball-*/*.tar.gz; do
+          # Detached GPG signatures (.asc) are uploaded alongside their package.
+          for f in \
+            cmux-linux-deb-*/*.deb cmux-linux-deb-*/*.deb.asc \
+            cmux-linux-rpm-*/*.rpm cmux-linux-rpm-*/*.rpm.asc \
+            cmux-linux-tarball-*/*.tar.gz cmux-linux-tarball-*/*.tar.gz.asc; do
             [ -f "$f" ] && ASSETS+=("$f")
           done
 

--- a/docs/release/SIGNING.md
+++ b/docs/release/SIGNING.md
@@ -159,10 +159,12 @@ To rotate the signing key:
 - **CI logs show "LINUX_GPG_PRIVATE_KEY_BASE64 not set — skipping"**:
   the secret is missing on this fork. Set it (see above) and re-run
   the release workflow.
-- **`rpmsign: line N: unexpected EOF while looking for matching '"'`**:
-  passphrase contains characters that break the heredoc. Avoid `'`
-  and `"` in the passphrase, or update `%__gpg_sign_cmd` in the script
-  to read the passphrase from a file descriptor instead of a heredoc.
+- **rpmsign quoting issues with passphrase**: the script reads the
+  passphrase via `--passphrase-file` (file lives inside the ephemeral
+  `GNUPGHOME`), so passphrase contents are not subject to shell quoting
+  rules. If you see quoting errors in `rpmsign` output, the script has
+  been edited to embed the passphrase in `%__gpg_sign_cmd` directly —
+  revert to the `--passphrase-file` form.
 - **`gpg: decryption failed: No secret key`**: `LINUX_GPG_KEY_ID`
   doesn't match the imported key. Use the long key ID from
   `gpg --list-secret-keys --keyid-format=long`.

--- a/docs/release/SIGNING.md
+++ b/docs/release/SIGNING.md
@@ -1,0 +1,172 @@
+# Linux package signing runbook
+
+This document covers GPG signing for the Linux release pipeline (DEB, RPM,
+tarball). Signing is performed in CI via `scripts/sign-linux-packages.sh`,
+gated on three GitHub Actions secrets in the `Jesssullivan/cmux` repo. If
+the secrets are absent the script no-ops, so local/unsigned builds keep
+working.
+
+## What gets signed
+
+| Artifact         | Signature              | Verification                   |
+|------------------|------------------------|--------------------------------|
+| `cmux_*.deb`     | Detached `*.deb.asc`   | `gpg --verify cmux_*.deb.asc`  |
+| `cmux-*.rpm`     | In-package + `*.asc`   | `rpm -K cmux-*.rpm`            |
+| `cmux-*.tar.gz`  | Detached `*.tar.gz.asc`| `gpg --verify *.tar.gz.asc`    |
+
+RPMs get **both** an in-package signature (`rpmsign --addsign`, the form
+`dnf` and `rpm -K` understand) and a sibling detached `.asc` for tooling
+that prefers detached signatures (mirrors, repo-md indexers, package-sig
+audit scripts).
+
+## CI architecture
+
+```
+build-deb (matrix: amd64 + arm64)
+  └─ assemble .deb + .tar.gz
+  └─ Sign DEB and tarball with GPG  ← scripts/sign-linux-packages.sh
+  └─ upload-artifact: *.deb + *.deb.asc
+  └─ upload-artifact: *.tar.gz + *.tar.gz.asc
+
+build-rpm (matrix: amd64 + arm64)
+  └─ assemble .rpm
+  └─ Sign RPM with GPG              ← scripts/sign-linux-packages.sh
+  └─ upload-artifact: *.rpm + *.rpm.asc
+
+release
+  └─ download-artifact (all matrix legs)
+  └─ gh release upload (.deb, .rpm, .tar.gz, and all .asc siblings)
+```
+
+The signing script is **idempotent**:
+
+- Re-running on already-signed artifacts overwrites existing `.asc` files
+- `rpmsign --addsign` replaces an existing in-package signature
+- Each invocation creates a fresh ephemeral `GNUPGHOME` and tears it down
+  on exit (via `trap cleanup EXIT`), so the host keyring is never touched
+
+## Required GitHub Actions secrets
+
+Set these on the **`Jesssullivan/cmux`** repo (Settings → Secrets and
+variables → Actions). All three must be present for signing to run; if
+`LINUX_GPG_PRIVATE_KEY_BASE64` is missing the script exits 0 with a
+warning and the release continues unsigned.
+
+| Secret                            | Format                                | Notes                              |
+|-----------------------------------|---------------------------------------|------------------------------------|
+| `LINUX_GPG_PRIVATE_KEY_BASE64`    | base64-encoded ASCII-armored secret   | See "Generate the key" below      |
+| `LINUX_GPG_PASSPHRASE`            | UTF-8 plaintext                        | Treat as high-sensitivity         |
+| `LINUX_GPG_KEY_ID`                | fingerprint or short ID                | Used as `--local-user`/`%_gpg_name` |
+
+## Generate the key (one-time)
+
+Generate a dedicated release-signing key (do not reuse a personal key).
+Use a strong passphrase; rotate the key annually or on compromise.
+
+```bash
+# 1. Generate the key (interactive). RSA 4096 / sign-only / no expiry,
+#    or set --expire-date 1y if you want forced annual rotation.
+gpg --full-generate-key
+#   Real name:    cmux release signing
+#   Email:        releases@example.invalid     (use a non-personal addr)
+#   Comment:      cmux Linux release packages
+
+# 2. Capture the key fingerprint
+gpg --list-secret-keys --keyid-format=long
+#   sec   rsa4096/ABCDEF0123456789 2026-04-17 [SC]
+#         FULL40CHARFINGERPRINTGOESHEREFOR...
+
+# 3. Export and base64-encode the secret key
+gpg --export-secret-keys --armor "ABCDEF0123456789" | base64 -w0 > linux-gpg-key.b64
+
+# 4. Set the three GitHub Actions secrets
+gh secret set LINUX_GPG_PRIVATE_KEY_BASE64 \
+  --repo Jesssullivan/cmux \
+  --body "$(cat linux-gpg-key.b64)"
+gh secret set LINUX_GPG_PASSPHRASE --repo Jesssullivan/cmux
+gh secret set LINUX_GPG_KEY_ID --repo Jesssullivan/cmux \
+  --body "ABCDEF0123456789"
+
+# 5. Wipe the local copy
+shred -u linux-gpg-key.b64
+```
+
+Also export the **public** key — users need it to verify:
+
+```bash
+gpg --export --armor "ABCDEF0123456789" > docs/release/cmux-release-signing-key.asc
+```
+
+Commit `docs/release/cmux-release-signing-key.asc` to the repo and link
+it from the project README so users have a stable place to fetch it.
+
+## End-user verification
+
+Steps to give to users (paste into the release notes / README):
+
+```bash
+# Import the cmux release-signing public key
+curl -L https://github.com/Jesssullivan/cmux/raw/main/docs/release/cmux-release-signing-key.asc \
+  | gpg --import
+
+# Verify a DEB
+gpg --verify cmux_0.75.0_amd64.deb.asc cmux_0.75.0_amd64.deb
+
+# Verify a tarball
+gpg --verify cmux-0.75.0-linux-amd64.tar.gz.asc cmux-0.75.0-linux-amd64.tar.gz
+
+# Verify an RPM (in-package signature)
+rpm --import https://github.com/Jesssullivan/cmux/raw/main/docs/release/cmux-release-signing-key.asc
+rpm -K cmux-0.75.0-1.x86_64.rpm
+# expected: digests signatures OK
+```
+
+`apt-get` users with a third-party repo would normally pin the key under
+`/etc/apt/keyrings/`; for direct `.deb` downloads the detached `.asc`
+verification above is the supported path.
+
+## Local testing of the signing script
+
+The script is safe to run locally — it only signs when all three env
+vars are present, and uses an ephemeral `GNUPGHOME`:
+
+```bash
+# No-op path (no secrets in env): exits 0 with a warning
+bash scripts/sign-linux-packages.sh /tmp/some-empty-dir
+
+# Real signing locally (e.g. against a test key in your own keyring)
+LINUX_GPG_PRIVATE_KEY_BASE64="$(gpg --export-secret-keys --armor TESTKEYID | base64 -w0)" \
+LINUX_GPG_PASSPHRASE='your-test-passphrase' \
+LINUX_GPG_KEY_ID='TESTKEYID' \
+  bash scripts/sign-linux-packages.sh /path/to/dir/with/artifacts
+```
+
+## Rotation
+
+To rotate the signing key:
+
+1. Generate a new key per "Generate the key" above
+2. Update the three GitHub Actions secrets
+3. Commit the new public key to `docs/release/cmux-release-signing-key.asc`
+   (replace, not append — a single current key is simpler for users)
+4. Mention the rotation in the next release's notes
+5. Optionally publish a revocation cert for the old key:
+   `gpg --gen-revoke OLDKEYID > old-key-revoke.asc` and import that
+   into a public keyserver
+
+## Troubleshooting
+
+- **CI logs show "LINUX_GPG_PRIVATE_KEY_BASE64 not set — skipping"**:
+  the secret is missing on this fork. Set it (see above) and re-run
+  the release workflow.
+- **`rpmsign: line N: unexpected EOF while looking for matching '"'`**:
+  passphrase contains characters that break the heredoc. Avoid `'`
+  and `"` in the passphrase, or update `%__gpg_sign_cmd` in the script
+  to read the passphrase from a file descriptor instead of a heredoc.
+- **`gpg: decryption failed: No secret key`**: `LINUX_GPG_KEY_ID`
+  doesn't match the imported key. Use the long key ID from
+  `gpg --list-secret-keys --keyid-format=long`.
+- **Detached `.asc` missing from release**: check the matrix-leg
+  artifact (`cmux-linux-deb-amd64`, etc.) actually contains the
+  `.asc`. The `if-no-files-found: error` upload setting should fail
+  the job loudly if it doesn't.

--- a/scripts/sign-linux-packages.sh
+++ b/scripts/sign-linux-packages.sh
@@ -82,13 +82,21 @@ if ! gpg --list-secret-keys "$LINUX_GPG_KEY_ID" >/dev/null 2>&1; then
   exit 1
 fi
 
+# Write the passphrase to a file inside the ephemeral GNUPGHOME so it
+# gets cleaned up by `trap cleanup EXIT`. Using --passphrase-file avoids
+# embedding shell-specific syntax (here-strings) in %__gpg_sign_cmd —
+# rpmsign may invoke the macro under /bin/sh which is not always bash.
+PASSPHRASE_FILE="$(mktemp "$GNUPGHOME/passphrase.XXXXXX")"
+chmod 600 "$PASSPHRASE_FILE"
+printf '%s' "$LINUX_GPG_PASSPHRASE" > "$PASSPHRASE_FILE"
+
 # rpmsign reads ~/.rpmmacros — point it at the imported key
 RPMMACROS="$HOME/.rpmmacros"
 if command -v rpmsign >/dev/null 2>&1; then
   cat > "$RPMMACROS" <<RPMCONF
 %_signature gpg
 %_gpg_name $LINUX_GPG_KEY_ID
-%__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --pinentry-mode loopback --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename} 3<<<"\$LINUX_GPG_PASSPHRASE"
+%__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --pinentry-mode loopback --passphrase-file ${PASSPHRASE_FILE} --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
 RPMCONF
 fi
 
@@ -98,11 +106,15 @@ sign_detached() {
   echo "sign-linux-packages: signing $file → $out"
   gpg --batch --yes \
     --pinentry-mode loopback \
-    --passphrase-fd 0 \
+    --passphrase-file "$PASSPHRASE_FILE" \
     --local-user "$LINUX_GPG_KEY_ID" \
     --armor --detach-sign \
     --output "$out" \
-    "$file" <<<"$LINUX_GPG_PASSPHRASE"
+    "$file"
+  # Verify immediately so a bad passphrase / wrong key ID / corrupted
+  # import surfaces here in CI rather than at user-verify time.
+  echo "sign-linux-packages: verifying $out"
+  gpg --batch --verify "$out" "$file" 2>&1 | sed 's/^/  gpg: /'
 }
 
 sign_rpm() {
@@ -113,8 +125,15 @@ sign_rpm() {
     sign_detached "$file"
     return
   fi
-  LINUX_GPG_PASSPHRASE="$LINUX_GPG_PASSPHRASE" rpmsign --addsign "$file"
-  # Also produce a detached sig for tooling that prefers it
+  rpmsign --addsign "$file"
+  # Verify the in-package signature was actually applied.
+  echo "sign-linux-packages: verifying in-package RPM signature for $file"
+  rpm -K "$file" 2>&1 | sed 's/^/  rpm: /'
+  if ! rpm -K "$file" | grep -q 'signatures OK'; then
+    echo "sign-linux-packages: ERROR — RPM signature verification failed for $file" >&2
+    exit 1
+  fi
+  # Also produce a detached sig for tooling that prefers it (and verify it).
   sign_detached "$file"
 }
 
@@ -132,7 +151,12 @@ for f in "$ARTIFACT_DIR"/*.rpm; do
 done
 
 if [ "$signed_count" -eq 0 ]; then
-  echo "sign-linux-packages: WARN — no artifacts found in $ARTIFACT_DIR (looked for *.deb, *.rpm, *.tar.gz)" >&2
+  # Reaching here means secrets ARE set (the early no-secret no-op exited
+  # at line ~31). If no artifacts exist the build is broken — fail loud
+  # so the release pipeline doesn't silently ship unsigned bits.
+  echo "sign-linux-packages: ERROR — secrets are set but no artifacts found in $ARTIFACT_DIR" >&2
+  echo "  (looked for *.deb, *.rpm, *.tar.gz; check the build step)" >&2
+  exit 1
 else
   echo "sign-linux-packages: signed $signed_count artifact(s) in $ARTIFACT_DIR"
 fi

--- a/scripts/sign-linux-packages.sh
+++ b/scripts/sign-linux-packages.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Sign Linux release artifacts (.deb, .rpm, .tar.gz) with GPG in CI.
+#
+# Reads the signing key + passphrase + key ID from environment:
+#   LINUX_GPG_PRIVATE_KEY_BASE64   base64-encoded ASCII-armored private key
+#                                  (gpg --export-secret-keys --armor <KEYID> | base64 -w0)
+#   LINUX_GPG_PASSPHRASE           passphrase for the key
+#   LINUX_GPG_KEY_ID               key fingerprint or short ID (used as default-key)
+#
+# If LINUX_GPG_PRIVATE_KEY_BASE64 is empty or unset, the script no-ops with a
+# warning so that local builds (without secrets) continue to work.
+#
+# Signs every matching artifact in $1 (default: current directory):
+#   *.deb     → detached *.asc next to the file
+#   *.tar.gz  → detached *.asc next to the file
+#   *.rpm     → in-package signature via `rpmsign --addsign` (verify with `rpm -K`)
+#
+# The script uses an ephemeral GNUPGHOME under a `mktemp -d` so the host
+# keyring is never touched, and cleans up on exit via trap.
+#
+# Idempotent: re-running on already-signed artifacts is harmless (existing
+# `.asc` is overwritten; `rpmsign --addsign` replaces the existing signature).
+
+set -euo pipefail
+
+ARTIFACT_DIR="${1:-.}"
+
+if [ -z "${LINUX_GPG_PRIVATE_KEY_BASE64:-}" ]; then
+  echo "sign-linux-packages: LINUX_GPG_PRIVATE_KEY_BASE64 not set — skipping (no-op for local/unsigned builds)"
+  exit 0
+fi
+
+if [ -z "${LINUX_GPG_PASSPHRASE:-}" ]; then
+  echo "sign-linux-packages: ERROR — LINUX_GPG_PRIVATE_KEY_BASE64 is set but LINUX_GPG_PASSPHRASE is missing" >&2
+  exit 1
+fi
+
+if [ -z "${LINUX_GPG_KEY_ID:-}" ]; then
+  echo "sign-linux-packages: ERROR — LINUX_GPG_PRIVATE_KEY_BASE64 is set but LINUX_GPG_KEY_ID is missing" >&2
+  exit 1
+fi
+
+if [ ! -d "$ARTIFACT_DIR" ]; then
+  echo "sign-linux-packages: ERROR — artifact dir not found: $ARTIFACT_DIR" >&2
+  exit 1
+fi
+
+for tool in gpg base64; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "sign-linux-packages: ERROR — required tool not found: $tool" >&2
+    exit 1
+  fi
+done
+
+# Ephemeral keyring — never touch the host's ~/.gnupg
+GNUPGHOME="$(mktemp -d)"
+export GNUPGHOME
+chmod 700 "$GNUPGHOME"
+
+cleanup() {
+  # Best-effort agent shutdown so the temp dir cleanup doesn't race
+  gpgconf --kill gpg-agent 2>/dev/null || true
+  rm -rf "$GNUPGHOME"
+}
+trap cleanup EXIT
+
+# Allow non-interactive operation
+cat > "$GNUPGHOME/gpg.conf" <<'GPGCONF'
+batch
+no-tty
+pinentry-mode loopback
+trust-model always
+GPGCONF
+
+# Import the key
+echo "sign-linux-packages: importing key $LINUX_GPG_KEY_ID into ephemeral GNUPGHOME"
+echo "$LINUX_GPG_PRIVATE_KEY_BASE64" | base64 -d | gpg --import 2>&1 | sed 's/^/  gpg: /'
+
+# Verify the key is present
+if ! gpg --list-secret-keys "$LINUX_GPG_KEY_ID" >/dev/null 2>&1; then
+  echo "sign-linux-packages: ERROR — key $LINUX_GPG_KEY_ID not found after import" >&2
+  exit 1
+fi
+
+# rpmsign reads ~/.rpmmacros — point it at the imported key
+RPMMACROS="$HOME/.rpmmacros"
+if command -v rpmsign >/dev/null 2>&1; then
+  cat > "$RPMMACROS" <<RPMCONF
+%_signature gpg
+%_gpg_name $LINUX_GPG_KEY_ID
+%__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --pinentry-mode loopback --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename} 3<<<"\$LINUX_GPG_PASSPHRASE"
+RPMCONF
+fi
+
+sign_detached() {
+  local file="$1"
+  local out="${file}.asc"
+  echo "sign-linux-packages: signing $file → $out"
+  gpg --batch --yes \
+    --pinentry-mode loopback \
+    --passphrase-fd 0 \
+    --local-user "$LINUX_GPG_KEY_ID" \
+    --armor --detach-sign \
+    --output "$out" \
+    "$file" <<<"$LINUX_GPG_PASSPHRASE"
+}
+
+sign_rpm() {
+  local file="$1"
+  echo "sign-linux-packages: rpmsign --addsign $file"
+  if ! command -v rpmsign >/dev/null 2>&1; then
+    echo "sign-linux-packages: WARN — rpmsign not available; skipping in-package RPM signature for $file" >&2
+    sign_detached "$file"
+    return
+  fi
+  LINUX_GPG_PASSPHRASE="$LINUX_GPG_PASSPHRASE" rpmsign --addsign "$file"
+  # Also produce a detached sig for tooling that prefers it
+  sign_detached "$file"
+}
+
+shopt -s nullglob
+
+signed_count=0
+for f in "$ARTIFACT_DIR"/*.deb "$ARTIFACT_DIR"/*.tar.gz; do
+  sign_detached "$f"
+  signed_count=$((signed_count + 1))
+done
+
+for f in "$ARTIFACT_DIR"/*.rpm; do
+  sign_rpm "$f"
+  signed_count=$((signed_count + 1))
+done
+
+if [ "$signed_count" -eq 0 ]; then
+  echo "sign-linux-packages: WARN — no artifacts found in $ARTIFACT_DIR (looked for *.deb, *.rpm, *.tar.gz)" >&2
+else
+  echo "sign-linux-packages: signed $signed_count artifact(s) in $ARTIFACT_DIR"
+fi


### PR DESCRIPTION
## Summary

Wires GPG signing into the Linux release pipeline. Every `.deb`, `.rpm`, and `.tar.gz` produced by `release-linux.yml` now ships with a verifiable signature.

- **DEB / tarball**: detached `*.asc` signatures (`gpg --detach-sign --armor`)
- **RPM**: in-package signature via `rpmsign --addsign` + sibling `*.asc` for detached-sig tooling
  - `rpm -K cmux-*.rpm` → digests + signatures OK
  - `gpg --verify cmux-*.rpm.asc cmux-*.rpm` → also works
- **No-op fallback**: if `LINUX_GPG_PRIVATE_KEY_BASE64` is unset the script exits 0 with a warning, so local/unsigned/fork builds keep working
- **Ephemeral keyring**: `GNUPGHOME=$(mktemp -d)` + `trap cleanup EXIT` + `gpgconf --kill gpg-agent` — host keyring never touched, no agent state survives the job
- **Idempotent**: re-running overwrites existing `.asc` files; `rpmsign --addsign` replaces any existing in-package signature

## Required secrets (set on `Jesssullivan/cmux`)

| Secret | Format |
|---|---|
| `LINUX_GPG_PRIVATE_KEY_BASE64` | base64 of ASCII-armored secret key |
| `LINUX_GPG_PASSPHRASE` | UTF-8 plaintext |
| `LINUX_GPG_KEY_ID` | fingerprint or short ID |

Until the secrets are set, releases continue to ship unsigned artifacts (script no-ops). After setting the secrets, the next tag-triggered run will sign automatically.

Full key-generation, provisioning, end-user verification, rotation, and troubleshooting steps live in `docs/release/SIGNING.md`.

## Files changed

- `scripts/sign-linux-packages.sh` (new, 134 lines, mode 755)
- `.github/workflows/release-linux.yml`
  - DEB job: new `Sign DEB and tarball with GPG` step + `*.asc` paths in upload-artifact
  - RPM job: new `Sign RPM with GPG` step + `*.asc` paths in upload-artifact + `rpm-sign gnupg2` added to Fedora dnf deps
  - Release job: `gh release upload` glob extended to include `.asc` siblings
- `docs/release/SIGNING.md` (new, operator runbook)

## Test plan

- [ ] Workflow YAML parses (`uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/release-linux.yml'))"` ✓ done locally)
- [ ] No-op path verified locally: `bash scripts/sign-linux-packages.sh /tmp` prints `LINUX_GPG_PRIVATE_KEY_BASE64 not set — skipping` and exits 0 ✓ done
- [ ] CI green for DEB/RPM matrix (no signing executed yet — secrets not set, script no-ops as designed)
- [ ] After secrets are provisioned: trigger a real release tag, confirm `.asc` files appear in the release page, run `gpg --verify` and `rpm -K` end-to-end
- [ ] Update README to document the public key + verification commands once the key is published

Closes: #214
Refs: TIN-177