### PR TITLE
test(socket): allowlist runner + Phase 1 candidate gate

### DIFF
--- a/.github/workflows/test-socket.yml
+++ b/.github/workflows/test-socket.yml
@@ -53,6 +53,11 @@ jobs:
         continue-on-error: true
         env:
           TEST_FILTER: ${{ inputs.test_filter || '' }}
+          # Phase 1 candidate gate: run extra Linux candidate tests as
+          # non-fatal observations. After consistent green runs, promote
+          # candidates into BASELINE in the runner script. See cmux #216
+          # / TIN-183 for the expansion plan.
+          CMUX_TEST_PHASE1: '1'
         run: nix develop --command bash scripts/run-socket-tests.sh
 
       - name: Upload test results

--- a/scripts/run-socket-tests.sh
+++ b/scripts/run-socket-tests.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 # Socket test runner for cmux-linux. Run inside: nix develop --command bash scripts/run-socket-tests.sh
+#
+# Test selection model: explicit baseline allowlist + opt-in candidate set.
+#
+#   BASELINE             Tests that pass green on every CI run. A failure here
+#                        fails the job. Keep this list small and stable.
+#
+#   CANDIDATES_PHASE1    Tests we believe should pass on Linux but have not
+#                        verified yet. Run only when CMUX_TEST_PHASE1=1.
+#                        Failures are reported but do NOT fail the job — the
+#                        gate exists so we can observe behavior on real CI
+#                        without regressing the green baseline. After several
+#                        consecutive green runs, promote into BASELINE.
+#
+# Adding a new test:
+#   1. Land the test in tests_v2/test_*.py.
+#   2. If you believe it'll pass on Linux, add the basename to
+#      CANDIDATES_PHASE1 and set CMUX_TEST_PHASE1=1 in CI for at least
+#      one merged PR run to observe.
+#   3. If green, move from CANDIDATES_PHASE1 to BASELINE and drop the gate.
+#
+# Tracking issue: #216 (TIN-183 — expand tests_v2 Linux coverage).
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -56,68 +77,121 @@ if [ ! -S "$CMUX_SOCKET" ]; then
 fi
 echo "Socket ready"
 
-# Discover tests
+# ── Baseline allowlist ──────────────────────────────────────────────
+# The 15 tests known to pass on cmux-linux today. A failure in any of
+# these fails the job.
+BASELINE=(
+  test_close_surface_selection
+  test_close_workspace_selection
+  test_focus_notification_dismiss
+  test_nested_split_no_detach_during_update
+  test_notification_socket_api
+  test_pane_break_swap_preserve_focus
+  test_pane_operations
+  test_signals_auto
+  test_surface_split_tree
+  test_system_api
+  test_trigger_flash
+  test_windows_api
+  test_workspace_lifecycle
+  test_workspace_navigation
+  test_workspace_reorder
+)
+
+# ── Phase 1 candidate allowlist (gated) ─────────────────────────────
+# Tests we believe should pass on Linux but have not verified. Run only
+# when CMUX_TEST_PHASE1=1. Candidate failures are reported but do not
+# fail the job — see header comment for promotion workflow.
+CANDIDATES_PHASE1=(
+  test_browser_open_split_reuse_policy
+  test_workspace_create_background_starts_terminal
+  test_workspace_create_initial_env
+)
+
+# Build the test list. Apply TEST_FILTER if set (case-style glob).
 TESTS=()
-for f in "$TESTS_DIR"/test_*.py; do
-  [ -f "$f" ] || continue
-  name=$(basename "$f")
-  [ -n "$FILTER" ] && case "$name" in $FILTER) ;; *) continue ;; esac
-  case "$name" in
-    # Require macOS app / GUI interaction
-    test_browser_*|test_cli_*|test_ctrl_interactive*|test_ssh_*) continue ;;
-    test_visual_*|test_lint_*|test_command_palette_*|test_tmux_*) continue ;;
-    # Require macOS shortcuts, panel_snapshot, simulate_type, bonsplit_underflow
-    test_nested_split_does_not_disappear*|test_nested_split_no_arranged_subview*) continue ;;
-    test_nested_split_panel_routing*) continue ;;
-    test_split_cmd_*|test_split_flash_*) continue ;;
-    test_shortcut_window_scope*|test_tab_dragging*) continue ;;
-    test_ctrl_enter_keybind*) continue ;;
-    test_new_tab_interactive*|test_new_tab_render*) continue ;;
-    test_initial_terminal_interactive*) continue ;;
-    test_terminal_focus_routing*|test_terminal_input_render*) continue ;;
-    test_v1_panel_creation*|test_update_timing*) continue ;;
-    # Require real terminal PTY / I/O
-    test_pane_resize_*|test_read_screen_capture*) continue ;;
-    test_surface_list_custom_titles*) continue ;;
-    test_workspace_create_background*|test_workspace_create_initial_env*) continue ;;
-    test_ctrl_socket*) continue ;;
-    # Require macOS CLI binary
-    test_rename_tab_cli*|test_rename_window_workspace*) continue ;;
-    test_tab_workspace_action_naming*|test_workspace_relative*) continue ;;
-    # Require layout_debug (macOS debug-only)
-    test_nested_split_preserves_existing*) continue ;;
-    # Require macOS process patterns (pgrep .app/Contents/MacOS)
-    test_cpu_usage*|test_cpu_notifications*) continue ;;
-    # Require terminal send + OSC sequences for notification tests
-    test_notifications*) continue ;;
-    # Require real surface.move/reorder implementation
-    test_surface_move_reorder_api*) continue ;;
-  esac
+CANDIDATE_NAMES=()
+
+filter_match() {
+  local name="$1"
+  [ -z "$FILTER" ] && return 0
+  case "$name" in $FILTER) return 0 ;; *) return 1 ;; esac
+}
+
+resolve_test() {
+  local name="$1"
+  local f="$TESTS_DIR/${name}.py"
+  if [ ! -f "$f" ]; then
+    echo "WARN: allowlisted test missing on disk: $name" >&2
+    return 1
+  fi
+  filter_match "$name" || return 1
   TESTS+=("$f")
+  return 0
+}
+
+for name in "${BASELINE[@]}"; do
+  resolve_test "$name" || true
 done
 
+if [ "${CMUX_TEST_PHASE1:-0}" = "1" ]; then
+  echo "=== Phase 1 candidate gate enabled (CMUX_TEST_PHASE1=1) ==="
+  for name in "${CANDIDATES_PHASE1[@]}"; do
+    if resolve_test "$name"; then
+      CANDIDATE_NAMES+=("$name")
+    fi
+  done
+fi
+
+is_candidate() {
+  local needle="$1"
+  for c in "${CANDIDATE_NAMES[@]}"; do
+    [ "$c" = "$needle" ] && return 0
+  done
+  return 1
+}
+
 TOTAL=${#TESTS[@]}
-echo "=== Running $TOTAL tests ==="
+echo "=== Running $TOTAL tests (${#BASELINE[@]} baseline, ${#CANDIDATE_NAMES[@]} phase1 candidates) ==="
 echo "TAP version 13" > "$TAP_FILE"
 echo "1..$TOTAL" >> "$TAP_FILE"
 
-PASS=0 FAIL=0 NUM=0
+PASS=0 FAIL=0 NUM=0 CAND_PASS=0 CAND_FAIL=0
 for test_file in "${TESTS[@]}"; do
   NUM=$((NUM + 1))
   name=$(basename "$test_file" .py)
   if timeout 5 python3 "$test_file" > "/tmp/socket-tests-${name}.log" 2>&1; then
-    PASS=$((PASS + 1))
-    echo "ok $NUM $name" >> "$TAP_FILE"
-    echo "PASS: $name"
+    if is_candidate "$name"; then
+      CAND_PASS=$((CAND_PASS + 1))
+      echo "ok $NUM $name # candidate" >> "$TAP_FILE"
+      echo "PASS: $name (candidate)"
+    else
+      PASS=$((PASS + 1))
+      echo "ok $NUM $name" >> "$TAP_FILE"
+      echo "PASS: $name"
+    fi
   else
-    FAIL=$((FAIL + 1))
-    echo "not ok $NUM $name" >> "$TAP_FILE"
-    echo "FAIL: $name"
+    if is_candidate "$name"; then
+      CAND_FAIL=$((CAND_FAIL + 1))
+      # TAP-style "todo" — visible as a failure but conventionally non-fatal
+      echo "not ok $NUM $name # TODO candidate (non-fatal)" >> "$TAP_FILE"
+      echo "FAIL: $name (candidate, non-fatal)"
+    else
+      FAIL=$((FAIL + 1))
+      echo "not ok $NUM $name" >> "$TAP_FILE"
+      echo "FAIL: $name"
+    fi
   fi
 done
 
 echo ""
-echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+echo "=== Baseline: $PASS/${#BASELINE[@]} passed, $FAIL failed ==="
+if [ "${#CANDIDATE_NAMES[@]}" -gt 0 ]; then
+  echo "=== Phase 1 candidates: $CAND_PASS/${#CANDIDATE_NAMES[@]} passed, $CAND_FAIL failed (non-fatal) ==="
+fi
 echo "=== Daemon stderr ==="
 head -5 "$STDERR_LOG" 2>/dev/null
+
+# Only baseline failures fail the job. Phase 1 candidate failures are
+# observational — promote into BASELINE once consistently green.
 [ $FAIL -gt 0 ] && exit 1 || exit 0


### PR DESCRIPTION
## Summary

Phase 1 of cmux #216 / TIN-183 (expand `tests_v2` Linux coverage beyond the current 15/109).

This PR is **runner-only**: no Zig changes, no socket-command changes. It refactors the test selector and adds an opt-in mechanism for trying additional tests on real CI without ever risking the green baseline.

## What changed

### `scripts/run-socket-tests.sh` — allowlist + candidate gate

Before: a 28-pattern shell `case` blacklist that excluded test families by filename prefix. Adding/removing tests required reasoning about negative-space pattern overlaps.

After: two explicit lists.

- **`BASELINE`** — the 15 tests already known to pass on Linux. Failure here fails CI.
- **`CANDIDATES_PHASE1`** — opt-in via `CMUX_TEST_PHASE1=1`. Failures are reported in TAP as `not ok N name # TODO candidate (non-fatal)` and do **not** fail the job. After several consecutive green runs, candidates get promoted into BASELINE.

The header comments document the promotion workflow so the next contributor doesn't re-invent it.

### Phase 1 candidates

Three tests that the audit (TIN-183) identified as having all their socket calls present in the Linux dispatcher (`cmux-linux/src/socket.zig`):

- `test_browser_open_split_reuse_policy`
- `test_workspace_create_background_starts_terminal`
- `test_workspace_create_initial_env`

These may need a real surface even under `CMUX_NO_SURFACE=1`, which is exactly what the gate exists to find out.

### `.github/workflows/test-socket.yml`

Sets `CMUX_TEST_PHASE1: '1'` on the test step so the candidate gate runs by default. The existing `continue-on-error: true` on the step already prevents the job from failing the broader workflow on candidate-test failure (and the runner itself doesn't exit non-zero on candidate failure either — defense in depth).

## Why this approach

- **Zero baseline risk**: BASELINE is unchanged from current behavior. CI cannot regress through this PR.
- **Visibility**: Candidate results show in TAP output and in the run logs, so we learn from every CI invocation.
- **Reversible**: To disable Phase 1, set `CMUX_TEST_PHASE1: '0'`. To remove a flapping candidate, edit the array.
- **Documents intent**: The list of "things we want to make work next" is now in source rather than living only in tracking issues.

## Test plan

- [ ] Workflow YAML parses ✓ (validated locally)
- [ ] Runner script syntax-clean ✓ (`bash -n`)
- [ ] CI run shows the 15 baseline tests still passing
- [ ] CI run shows Phase 1 candidate results in TAP and run logs (pass-or-fail both fine)
- [ ] Candidate failures do not fail the `Run socket tests` step

## Follow-ups (separate issues, not this PR)

Phase 2 (in #216): minimal Linux socket shims for `surface.move`/`reorder` (real impl), `pane.resize`, `surface.action`, `browser.eval`/`get.title`/`wait`. Each unblocks 1-3 additional tests once landed.

Phase 3 areas (each gets own issue): debug command-palette family, debug input-simulation helpers, full browser automation surface, SSH remote subsystem, Linux Zig CLI parity.

Refs: #216, TIN-183