### PR TITLE
linux(socket): implement surface.action / tab.action (rename, pin, mark_read)

### DIFF
--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -219,6 +219,8 @@ const methods = .{
     .{ "surface.health", handleSurfaceHealth },
     .{ "surface.trigger_flash", handleSurfaceTriggerFlash },
     .{ "surface.clear_history", handleSurfaceClearHistory },
+    .{ "surface.action", handleSurfaceAction },
+    .{ "tab.action", handleSurfaceAction },
     .{ "pane.list", handlePaneList },
     .{ "pane.focus", handlePaneFocus },
     .{ "pane.create", handlePaneCreate },
@@ -1236,6 +1238,126 @@ fn handleSurfaceTriggerFlash(_: Allocator, params: json.Value) []const u8 {
 
 fn handleSurfaceClearHistory(_: Allocator, _: json.Value) []const u8 {
     return "{}"; // Terminal scrollback clear stub
+}
+
+/// surface.action / tab.action — apply a tab-level action to a surface.
+///
+/// Mirrors macOS `v2TabAction` (Sources/TerminalController.swift). Linux
+/// implements the trivial property-mutation actions (rename, clear_name,
+/// pin, unpin, mark_read, mark_unread). Tab-relative close/new actions
+/// (close_left, close_right, close_others, new_terminal_right,
+/// new_browser_right, reload, duplicate) are not yet wired and will return
+/// an `unsupported` error so callers can detect parity gaps.
+fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+
+    // Resolve workspace (param or current)
+    const ws = if (getParamString(params, "workspace_id")) |id_str|
+        if (findWorkspaceById(tm, id_str)) |found| found.ws else return "{\"error\":\"workspace not found\"}"
+    else
+        tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+
+    const action = getParamString(params, "action") orelse return "{\"error\":\"missing action\"}";
+
+    // Resolve target surface (surface_id, tab_id, or focused)
+    const target_id = if (getParamString(params, "surface_id")) |id_str|
+        findSurfaceInWorkspace(ws, id_str) orelse return "{\"error\":\"invalid surface_id\"}"
+    else if (getParamString(params, "tab_id")) |id_str|
+        findSurfaceInWorkspace(ws, id_str) orelse return "{\"error\":\"invalid tab_id\"}"
+    else
+        ws.focused_panel_id orelse return "{\"error\":\"no focused surface\"}";
+
+    const panel = ws.panels.get(target_id) orelse return "{\"error\":\"surface not found\"}";
+    const panel_hex = formatId(target_id);
+    const panel_id_slice: []const u8 = &panel_hex;
+
+    if (std.mem.eql(u8, action, "rename")) {
+        const title = getParamString(params, "title") orelse return "{\"error\":\"missing title\"}";
+        if (panel.custom_title) |old| ws.alloc.free(old);
+        panel.custom_title = ws.alloc.dupe(u8, title) catch return "{\"error\":\"alloc failed\"}";
+        if (window.getSidebar()) |sb| sb.refresh();
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"rename\",\"surface_id\":\"{s}\",\"title\":\"{s}\"}}",
+            .{ panel_id_slice, title },
+        ) catch "{}";
+    }
+
+    if (std.mem.eql(u8, action, "clear_name")) {
+        if (panel.custom_title) |old| {
+            ws.alloc.free(old);
+            panel.custom_title = null;
+        }
+        if (window.getSidebar()) |sb| sb.refresh();
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"clear_name\",\"surface_id\":\"{s}\"}}",
+            .{panel_id_slice},
+        ) catch "{}";
+    }
+
+    if (std.mem.eql(u8, action, "pin")) {
+        panel.is_pinned = true;
+        if (window.getSidebar()) |sb| sb.refresh();
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"pin\",\"surface_id\":\"{s}\",\"pinned\":true}}",
+            .{panel_id_slice},
+        ) catch "{}";
+    }
+
+    if (std.mem.eql(u8, action, "unpin")) {
+        panel.is_pinned = false;
+        if (window.getSidebar()) |sb| sb.refresh();
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"unpin\",\"surface_id\":\"{s}\",\"pinned\":false}}",
+            .{panel_id_slice},
+        ) catch "{}";
+    }
+
+    if (std.mem.eql(u8, action, "mark_read")) {
+        panel.is_manually_unread = false;
+        if (window.getSidebar()) |sb| sb.refresh();
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"mark_read\",\"surface_id\":\"{s}\"}}",
+            .{panel_id_slice},
+        ) catch "{}";
+    }
+
+    if (std.mem.eql(u8, action, "mark_unread")) {
+        panel.is_manually_unread = true;
+        if (window.getSidebar()) |sb| sb.refresh();
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"mark_unread\",\"surface_id\":\"{s}\"}}",
+            .{panel_id_slice},
+        ) catch "{}";
+    }
+
+    // Recognized but not yet implemented on Linux. Returning a structured
+    // error lets callers distinguish "wrong call" from "platform gap".
+    if (std.mem.eql(u8, action, "close_left") or
+        std.mem.eql(u8, action, "close_right") or
+        std.mem.eql(u8, action, "close_others") or
+        std.mem.eql(u8, action, "new_terminal_right") or
+        std.mem.eql(u8, action, "new_browser_right") or
+        std.mem.eql(u8, action, "reload") or
+        std.mem.eql(u8, action, "duplicate"))
+    {
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"error\":\"action not implemented on linux\",\"action\":\"{s}\"}}",
+            .{action},
+        ) catch "{\"error\":\"action not implemented on linux\"}";
+    }
+
+    return std.fmt.allocPrint(
+        alloc,
+        "{{\"error\":\"unsupported action\",\"action\":\"{s}\",\"supported\":[\"rename\",\"clear_name\",\"pin\",\"unpin\",\"mark_read\",\"mark_unread\"]}}",
+        .{action},
+    ) catch "{\"error\":\"unsupported action\"}";
 }
 
 // ── Batch 3: Additional Pane Operations ─────────────────────────────────

--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -1273,14 +1273,22 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
 
     if (std.mem.eql(u8, action, "rename")) {
         const title = getParamString(params, "title") orelse return "{\"error\":\"missing title\"}";
+        // Allocate the new value FIRST, then free the old. Otherwise an alloc
+        // failure leaves panel.custom_title pointing at freed memory.
+        const new_title = ws.alloc.dupe(u8, title) catch return "{\"error\":\"alloc failed\"}";
         if (panel.custom_title) |old| ws.alloc.free(old);
-        panel.custom_title = ws.alloc.dupe(u8, title) catch return "{\"error\":\"alloc failed\"}";
+        panel.custom_title = new_title;
         if (window.getSidebar()) |sb| sb.refresh();
-        return std.fmt.allocPrint(
-            alloc,
-            "{{\"action\":\"rename\",\"surface_id\":\"{s}\",\"title\":\"{s}\"}}",
-            .{ panel_id_slice, title },
-        ) catch "{}";
+        // Escape `title` via writeJsonString so quotes / backslashes / control
+        // chars in the user-supplied value cannot break the JSON envelope.
+        var buf: std.ArrayList(u8) = .empty;
+        const w = buf.writer(alloc);
+        w.writeAll("{\"action\":\"rename\",\"surface_id\":\"") catch return "{}";
+        w.writeAll(panel_id_slice) catch return "{}";
+        w.writeAll("\",\"title\":") catch return "{}";
+        writeJsonString(w, title) catch return "{}";
+        w.writeByte('}') catch return "{}";
+        return buf.toOwnedSlice(alloc) catch "{}";
     }
 
     if (std.mem.eql(u8, action, "clear_name")) {
@@ -1338,6 +1346,7 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
 
     // Recognized but not yet implemented on Linux. Returning a structured
     // error lets callers distinguish "wrong call" from "platform gap".
+    // `action` is user input — escape it via writeJsonString.
     if (std.mem.eql(u8, action, "close_left") or
         std.mem.eql(u8, action, "close_right") or
         std.mem.eql(u8, action, "close_others") or
@@ -1346,18 +1355,25 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
         std.mem.eql(u8, action, "reload") or
         std.mem.eql(u8, action, "duplicate"))
     {
-        return std.fmt.allocPrint(
-            alloc,
-            "{{\"error\":\"action not implemented on linux\",\"action\":\"{s}\"}}",
-            .{action},
-        ) catch "{\"error\":\"action not implemented on linux\"}";
+        var buf: std.ArrayList(u8) = .empty;
+        const w = buf.writer(alloc);
+        w.writeAll("{\"error\":\"action not implemented on linux\",\"action\":") catch
+            return "{\"error\":\"action not implemented on linux\"}";
+        writeJsonString(w, action) catch
+            return "{\"error\":\"action not implemented on linux\"}";
+        w.writeByte('}') catch return "{\"error\":\"action not implemented on linux\"}";
+        return buf.toOwnedSlice(alloc) catch "{\"error\":\"action not implemented on linux\"}";
     }
 
-    return std.fmt.allocPrint(
-        alloc,
-        "{{\"error\":\"unsupported action\",\"action\":\"{s}\",\"supported\":[\"rename\",\"clear_name\",\"pin\",\"unpin\",\"mark_read\",\"mark_unread\"]}}",
-        .{action},
-    ) catch "{\"error\":\"unsupported action\"}";
+    // Unsupported action — same escape treatment for `action` echo.
+    var buf: std.ArrayList(u8) = .empty;
+    const w = buf.writer(alloc);
+    w.writeAll("{\"error\":\"unsupported action\",\"action\":") catch
+        return "{\"error\":\"unsupported action\"}";
+    writeJsonString(w, action) catch return "{\"error\":\"unsupported action\"}";
+    w.writeAll(",\"supported\":[\"rename\",\"clear_name\",\"pin\",\"unpin\",\"mark_read\",\"mark_unread\"]}") catch
+        return "{\"error\":\"unsupported action\"}";
+    return buf.toOwnedSlice(alloc) catch "{\"error\":\"unsupported action\"}";
 }
 
 // ── Batch 3: Additional Pane Operations ─────────────────────────────────

--- a/tests_v2/test_surface_action_rename.py
+++ b/tests_v2/test_surface_action_rename.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Socket API: surface.action rename / clear_name / pin / unpin / mark_read / mark_unread.
+
+Pure socket round-trip test — no GUI, no CLI binary, no platform-specific
+filesystem assumptions. Designed to pass on both macOS and Linux daemons.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _surfaces_in(c: cmux, workspace_id: str) -> list[dict]:
+    """Return raw surface.list rows (dicts) for the given workspace."""
+    res = c._call("surface.list", {"workspace_id": workspace_id}) or {}
+    return list(res.get("surfaces") or [])
+
+
+def _find_surface(rows: list[dict], surface_id: str) -> dict:
+    for row in rows:
+        if str(row.get("id")) == surface_id:
+            return row
+    raise cmuxError(f"surface {surface_id} missing from list: {rows}")
+
+
+def main() -> int:
+    created_workspace: str | None = None
+    with cmux(SOCKET_PATH) as c:
+        # Create an isolated workspace so the test cannot disturb the user's
+        # current workspace state.
+        created_workspace = c.new_workspace()
+        if not created_workspace:
+            raise cmuxError("workspace.create returned no id")
+        c.select_workspace(created_workspace)
+        time.sleep(0.05)
+
+        # Locate the focused surface in the new workspace.
+        rows = _surfaces_in(c, created_workspace)
+        if not rows:
+            raise cmuxError(f"new workspace has no surfaces: {rows}")
+        focused = next((r for r in rows if r.get("focused")), rows[0])
+        surface_id = str(focused["id"])
+        original_title = str(focused.get("title", ""))
+
+        unique_title = f"renamed-via-action-{int(time.time() * 1000) % 100000}"
+
+        # ── rename ────────────────────────────────────────────────────────
+        result = c._call(
+            "surface.action",
+            {
+                "workspace_id": created_workspace,
+                "surface_id": surface_id,
+                "action": "rename",
+                "title": unique_title,
+            },
+        ) or {}
+        if result.get("action") != "rename":
+            raise cmuxError(f"rename: unexpected response: {result}")
+        if str(result.get("title")) != unique_title:
+            raise cmuxError(f"rename: title not echoed: {result}")
+
+        # Reflected in surface.list?
+        renamed = _find_surface(_surfaces_in(c, created_workspace), surface_id)
+        if str(renamed.get("title")) != unique_title:
+            raise cmuxError(
+                f"rename not reflected in surface.list: expected {unique_title!r}, "
+                f"got {renamed.get('title')!r}"
+            )
+
+        # ── tab.action alias should hit the same handler ──────────────────
+        alias_title = f"{unique_title}-alias"
+        alias_result = c._call(
+            "tab.action",
+            {
+                "workspace_id": created_workspace,
+                "tab_id": surface_id,
+                "action": "rename",
+                "title": alias_title,
+            },
+        ) or {}
+        if alias_result.get("action") != "rename":
+            raise cmuxError(f"tab.action alias: unexpected response: {alias_result}")
+        aliased = _find_surface(_surfaces_in(c, created_workspace), surface_id)
+        if str(aliased.get("title")) != alias_title:
+            raise cmuxError(
+                f"tab.action alias not reflected: expected {alias_title!r}, "
+                f"got {aliased.get('title')!r}"
+            )
+
+        # ── clear_name ────────────────────────────────────────────────────
+        cleared_resp = c._call(
+            "surface.action",
+            {
+                "workspace_id": created_workspace,
+                "surface_id": surface_id,
+                "action": "clear_name",
+            },
+        ) or {}
+        if cleared_resp.get("action") != "clear_name":
+            raise cmuxError(f"clear_name: unexpected response: {cleared_resp}")
+        cleared = _find_surface(_surfaces_in(c, created_workspace), surface_id)
+        if str(cleared.get("title")) == alias_title:
+            raise cmuxError(
+                f"clear_name did not drop custom title: still {cleared.get('title')!r}"
+            )
+        # Title falls back to process title or "Terminal"; we just assert it
+        # is no longer the custom alias.
+
+        # ── pin / unpin ───────────────────────────────────────────────────
+        pin_resp = c._call(
+            "surface.action",
+            {
+                "workspace_id": created_workspace,
+                "surface_id": surface_id,
+                "action": "pin",
+            },
+        ) or {}
+        if pin_resp.get("action") != "pin" or pin_resp.get("pinned") is not True:
+            raise cmuxError(f"pin: unexpected response: {pin_resp}")
+
+        unpin_resp = c._call(
+            "surface.action",
+            {
+                "workspace_id": created_workspace,
+                "surface_id": surface_id,
+                "action": "unpin",
+            },
+        ) or {}
+        if unpin_resp.get("action") != "unpin" or unpin_resp.get("pinned") is not False:
+            raise cmuxError(f"unpin: unexpected response: {unpin_resp}")
+
+        # ── mark_read / mark_unread ───────────────────────────────────────
+        for action in ("mark_unread", "mark_read"):
+            resp = c._call(
+                "surface.action",
+                {
+                    "workspace_id": created_workspace,
+                    "surface_id": surface_id,
+                    "action": action,
+                },
+            ) or {}
+            if resp.get("action") != action:
+                raise cmuxError(f"{action}: unexpected response: {resp}")
+
+        # ── unsupported action returns an error structure ─────────────────
+        try:
+            c._call(
+                "surface.action",
+                {
+                    "workspace_id": created_workspace,
+                    "surface_id": surface_id,
+                    "action": "definitely-not-a-real-action",
+                },
+            )
+            # Some daemons may return a JSON body with an "error" field while
+            # still marking the response ok=true. Either is acceptable.
+        except cmuxError:
+            pass  # expected
+
+        # ── focused-surface fallback (no surface_id provided) ─────────────
+        focus_fallback_title = f"{unique_title}-focused"
+        fallback_resp = c._call(
+            "surface.action",
+            {
+                "workspace_id": created_workspace,
+                "action": "rename",
+                "title": focus_fallback_title,
+            },
+        ) or {}
+        if fallback_resp.get("action") != "rename":
+            raise cmuxError(
+                f"focused-surface fallback: unexpected response: {fallback_resp}"
+            )
+
+        # Reset to clear the custom name we leaked into the workspace.
+        c._call(
+            "surface.action",
+            {
+                "workspace_id": created_workspace,
+                "surface_id": surface_id,
+                "action": "clear_name",
+            },
+        )
+
+        # Cleanup
+        c.close_workspace(created_workspace)
+        created_workspace = None
+
+    print("PASS: surface.action rename / clear_name / pin / unpin / mark_read / mark_unread")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except cmuxError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests_v2/test_surface_action_rename.py
+++ b/tests_v2/test_surface_action_rename.py
@@ -29,168 +29,180 @@ def _find_surface(rows: list[dict], surface_id: str) -> dict:
     raise cmuxError(f"surface {surface_id} missing from list: {rows}")
 
 
-def main() -> int:
-    created_workspace: str | None = None
-    with cmux(SOCKET_PATH) as c:
-        # Create an isolated workspace so the test cannot disturb the user's
-        # current workspace state.
-        created_workspace = c.new_workspace()
-        if not created_workspace:
-            raise cmuxError("workspace.create returned no id")
-        c.select_workspace(created_workspace)
-        time.sleep(0.05)
+def _run_assertions(c: cmux, created_workspace: str) -> None:
+    """Run the full surface.action / tab.action assertion suite.
 
-        # Locate the focused surface in the new workspace.
-        rows = _surfaces_in(c, created_workspace)
-        if not rows:
-            raise cmuxError(f"new workspace has no surfaces: {rows}")
-        focused = next((r for r in rows if r.get("focused")), rows[0])
-        surface_id = str(focused["id"])
-        original_title = str(focused.get("title", ""))
+    Caller owns lifecycle of `created_workspace` (creation + cleanup).
+    """
+    c.select_workspace(created_workspace)
+    time.sleep(0.05)
 
-        unique_title = f"renamed-via-action-{int(time.time() * 1000) % 100000}"
+    # Locate the focused surface in the new workspace.
+    rows = _surfaces_in(c, created_workspace)
+    if not rows:
+        raise cmuxError(f"new workspace has no surfaces: {rows}")
+    focused = next((r for r in rows if r.get("focused")), rows[0])
+    surface_id = str(focused["id"])
 
-        # ── rename ────────────────────────────────────────────────────────
-        result = c._call(
+    unique_title = f"renamed-via-action-{int(time.time() * 1000) % 100000}"
+
+    # ── rename ────────────────────────────────────────────────────────
+    result = c._call(
+        "surface.action",
+        {
+            "workspace_id": created_workspace,
+            "surface_id": surface_id,
+            "action": "rename",
+            "title": unique_title,
+        },
+    ) or {}
+    if result.get("action") != "rename":
+        raise cmuxError(f"rename: unexpected response: {result}")
+    if str(result.get("title")) != unique_title:
+        raise cmuxError(f"rename: title not echoed: {result}")
+
+    # Reflected in surface.list?
+    renamed = _find_surface(_surfaces_in(c, created_workspace), surface_id)
+    if str(renamed.get("title")) != unique_title:
+        raise cmuxError(
+            f"rename not reflected in surface.list: expected {unique_title!r}, "
+            f"got {renamed.get('title')!r}"
+        )
+
+    # ── tab.action alias should hit the same handler ──────────────────
+    alias_title = f"{unique_title}-alias"
+    alias_result = c._call(
+        "tab.action",
+        {
+            "workspace_id": created_workspace,
+            "tab_id": surface_id,
+            "action": "rename",
+            "title": alias_title,
+        },
+    ) or {}
+    if alias_result.get("action") != "rename":
+        raise cmuxError(f"tab.action alias: unexpected response: {alias_result}")
+    aliased = _find_surface(_surfaces_in(c, created_workspace), surface_id)
+    if str(aliased.get("title")) != alias_title:
+        raise cmuxError(
+            f"tab.action alias not reflected: expected {alias_title!r}, "
+            f"got {aliased.get('title')!r}"
+        )
+
+    # ── clear_name ────────────────────────────────────────────────────
+    cleared_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": created_workspace,
+            "surface_id": surface_id,
+            "action": "clear_name",
+        },
+    ) or {}
+    if cleared_resp.get("action") != "clear_name":
+        raise cmuxError(f"clear_name: unexpected response: {cleared_resp}")
+    cleared = _find_surface(_surfaces_in(c, created_workspace), surface_id)
+    if str(cleared.get("title")) == alias_title:
+        raise cmuxError(
+            f"clear_name did not drop custom title: still {cleared.get('title')!r}"
+        )
+    # Title falls back to process title or "Terminal"; we just assert it
+    # is no longer the custom alias.
+
+    # ── pin / unpin ───────────────────────────────────────────────────
+    pin_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": created_workspace,
+            "surface_id": surface_id,
+            "action": "pin",
+        },
+    ) or {}
+    if pin_resp.get("action") != "pin" or pin_resp.get("pinned") is not True:
+        raise cmuxError(f"pin: unexpected response: {pin_resp}")
+
+    unpin_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": created_workspace,
+            "surface_id": surface_id,
+            "action": "unpin",
+        },
+    ) or {}
+    if unpin_resp.get("action") != "unpin" or unpin_resp.get("pinned") is not False:
+        raise cmuxError(f"unpin: unexpected response: {unpin_resp}")
+
+    # ── mark_read / mark_unread ───────────────────────────────────────
+    for action in ("mark_unread", "mark_read"):
+        resp = c._call(
             "surface.action",
             {
                 "workspace_id": created_workspace,
                 "surface_id": surface_id,
-                "action": "rename",
-                "title": unique_title,
+                "action": action,
             },
         ) or {}
-        if result.get("action") != "rename":
-            raise cmuxError(f"rename: unexpected response: {result}")
-        if str(result.get("title")) != unique_title:
-            raise cmuxError(f"rename: title not echoed: {result}")
+        if resp.get("action") != action:
+            raise cmuxError(f"{action}: unexpected response: {resp}")
 
-        # Reflected in surface.list?
-        renamed = _find_surface(_surfaces_in(c, created_workspace), surface_id)
-        if str(renamed.get("title")) != unique_title:
-            raise cmuxError(
-                f"rename not reflected in surface.list: expected {unique_title!r}, "
-                f"got {renamed.get('title')!r}"
-            )
-
-        # ── tab.action alias should hit the same handler ──────────────────
-        alias_title = f"{unique_title}-alias"
-        alias_result = c._call(
-            "tab.action",
-            {
-                "workspace_id": created_workspace,
-                "tab_id": surface_id,
-                "action": "rename",
-                "title": alias_title,
-            },
-        ) or {}
-        if alias_result.get("action") != "rename":
-            raise cmuxError(f"tab.action alias: unexpected response: {alias_result}")
-        aliased = _find_surface(_surfaces_in(c, created_workspace), surface_id)
-        if str(aliased.get("title")) != alias_title:
-            raise cmuxError(
-                f"tab.action alias not reflected: expected {alias_title!r}, "
-                f"got {aliased.get('title')!r}"
-            )
-
-        # ── clear_name ────────────────────────────────────────────────────
-        cleared_resp = c._call(
-            "surface.action",
-            {
-                "workspace_id": created_workspace,
-                "surface_id": surface_id,
-                "action": "clear_name",
-            },
-        ) or {}
-        if cleared_resp.get("action") != "clear_name":
-            raise cmuxError(f"clear_name: unexpected response: {cleared_resp}")
-        cleared = _find_surface(_surfaces_in(c, created_workspace), surface_id)
-        if str(cleared.get("title")) == alias_title:
-            raise cmuxError(
-                f"clear_name did not drop custom title: still {cleared.get('title')!r}"
-            )
-        # Title falls back to process title or "Terminal"; we just assert it
-        # is no longer the custom alias.
-
-        # ── pin / unpin ───────────────────────────────────────────────────
-        pin_resp = c._call(
-            "surface.action",
-            {
-                "workspace_id": created_workspace,
-                "surface_id": surface_id,
-                "action": "pin",
-            },
-        ) or {}
-        if pin_resp.get("action") != "pin" or pin_resp.get("pinned") is not True:
-            raise cmuxError(f"pin: unexpected response: {pin_resp}")
-
-        unpin_resp = c._call(
-            "surface.action",
-            {
-                "workspace_id": created_workspace,
-                "surface_id": surface_id,
-                "action": "unpin",
-            },
-        ) or {}
-        if unpin_resp.get("action") != "unpin" or unpin_resp.get("pinned") is not False:
-            raise cmuxError(f"unpin: unexpected response: {unpin_resp}")
-
-        # ── mark_read / mark_unread ───────────────────────────────────────
-        for action in ("mark_unread", "mark_read"):
-            resp = c._call(
-                "surface.action",
-                {
-                    "workspace_id": created_workspace,
-                    "surface_id": surface_id,
-                    "action": action,
-                },
-            ) or {}
-            if resp.get("action") != action:
-                raise cmuxError(f"{action}: unexpected response: {resp}")
-
-        # ── unsupported action returns an error structure ─────────────────
-        try:
-            c._call(
-                "surface.action",
-                {
-                    "workspace_id": created_workspace,
-                    "surface_id": surface_id,
-                    "action": "definitely-not-a-real-action",
-                },
-            )
-            # Some daemons may return a JSON body with an "error" field while
-            # still marking the response ok=true. Either is acceptable.
-        except cmuxError:
-            pass  # expected
-
-        # ── focused-surface fallback (no surface_id provided) ─────────────
-        focus_fallback_title = f"{unique_title}-focused"
-        fallback_resp = c._call(
-            "surface.action",
-            {
-                "workspace_id": created_workspace,
-                "action": "rename",
-                "title": focus_fallback_title,
-            },
-        ) or {}
-        if fallback_resp.get("action") != "rename":
-            raise cmuxError(
-                f"focused-surface fallback: unexpected response: {fallback_resp}"
-            )
-
-        # Reset to clear the custom name we leaked into the workspace.
+    # ── unsupported action returns an error structure ─────────────────
+    try:
         c._call(
             "surface.action",
             {
                 "workspace_id": created_workspace,
                 "surface_id": surface_id,
-                "action": "clear_name",
+                "action": "definitely-not-a-real-action",
             },
         )
+        # Some daemons may return a JSON body with an "error" field while
+        # still marking the response ok=true. Either is acceptable.
+    except cmuxError:
+        pass  # expected
 
-        # Cleanup
-        c.close_workspace(created_workspace)
-        created_workspace = None
+    # ── focused-surface fallback (no surface_id provided) ─────────────
+    focus_fallback_title = f"{unique_title}-focused"
+    fallback_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": created_workspace,
+            "action": "rename",
+            "title": focus_fallback_title,
+        },
+    ) or {}
+    if fallback_resp.get("action") != "rename":
+        raise cmuxError(
+            f"focused-surface fallback: unexpected response: {fallback_resp}"
+        )
+
+    # Reset to clear the custom name we leaked into the workspace.
+    c._call(
+        "surface.action",
+        {
+            "workspace_id": created_workspace,
+            "surface_id": surface_id,
+            "action": "clear_name",
+        },
+    )
+
+
+def main() -> int:
+    created_workspace: str | None = None
+    with cmux(SOCKET_PATH) as c:
+        try:
+            # Create an isolated workspace so the test cannot disturb the
+            # user's current workspace state.
+            created_workspace = c.new_workspace()
+            if not created_workspace:
+                raise cmuxError("workspace.create returned no id")
+            _run_assertions(c, created_workspace)
+        finally:
+            # Always close the workspace, even if assertions raised — leaving
+            # one behind would corrupt subsequent tests on the same daemon.
+            if created_workspace is not None:
+                try:
+                    c.close_workspace(created_workspace)
+                except Exception:
+                    pass
 
     print("PASS: surface.action rename / clear_name / pin / unpin / mark_read / mark_unread")
     return 0


### PR DESCRIPTION
## Summary

Implements `surface.action` and its `tab.action` alias in the Linux daemon's socket dispatcher, mirroring macOS `v2TabAction`. Closes the most-requested per-surface metadata gap.

Supported actions (all map directly to existing fields on `Panel` in `cmux-linux/src/workspace.zig`):

| Action | Effect |
|---|---|
| `rename` | `Panel.custom_title = title` |
| `clear_name` | `Panel.custom_title = null` |
| `pin` / `unpin` | `Panel.is_pinned = true/false` |
| `mark_read` | `Panel.is_manually_unread = false` |
| `mark_unread` | `Panel.is_manually_unread = true` |

Tab-relative close/new actions (`close_left`, `close_right`, `close_others`, `new_terminal_right`, `new_browser_right`, `reload`, `duplicate`) are recognized but return a structured `"action not implemented on linux"` error — so callers can detect a parity gap vs. a typo without guessing.

`workspace_id`, `surface_id`, and `tab_id` parameters all mirror the macOS shape. When `surface_id`/`tab_id` are omitted, the focused surface is used.

The handler is registered for both `surface.action` and `tab.action` because Linux currently uses a 1:1 panel:pane mapping (one surface per pane = one "tab").

## Test plan

- [x] Pure-socket Python test added: `tests_v2/test_surface_action_rename.py`
  - Exercises every supported action against a fresh, isolated workspace
  - Verifies rename round-trips through `surface.list`
  - Verifies the `tab.action` alias hits the same handler
  - Verifies focused-surface fallback (no `surface_id`)
  - Cleans up its own workspace
- [x] No GUI/CLI binary dependency — runs unchanged on both macOS and Linux daemons
- [ ] Linux CI socket tests pick up the new test automatically (current `scripts/run-socket-tests.sh` blacklist has no exclusion for `test_surface_action_*`)
- [ ] After #217 (Phase 1 allowlist) merges, follow-up commit will add `test_surface_action_rename` to `BASELINE`

## Notes

- Title echo uses the existing `std.fmt.allocPrint` pattern (matches `handleSurfaceList` etc.). The pre-existing JSON-injection vulnerability in title echoing is left unchanged here; addressing it across the dispatcher is a separate cleanup PR.
- Sidebar UI refresh is invoked after each mutation via `window.getSidebar().refresh()` — same pattern as `handleWorkspaceRename`.

Refs: TIN-183
Closes part of #216