### PR TITLE
docs(release): add Flathub and Homebrew Cask runbooks

### DIFF
--- a/docs/release/flathub.md
+++ b/docs/release/flathub.md
@@ -1,0 +1,98 @@
+# Flathub submission runbook
+
+This is a **human-driven** runbook. The Flathub repos live under `flathub/*`
+on GitHub, which is third-party and intentionally off-limits to this fork's
+agent automation. Run these steps yourself; the agent can stage local
+changes (manifest tweaks, validation) but does not push to Flathub.
+
+## Prerequisites
+
+- A Flathub-enabled GitHub account (sign in at <https://flathub.org/login>)
+- `flatpak` and `flatpak-builder` installed locally (Linux only)
+- Network access; first-time builds pull large runtimes
+- A current cmux release tag in `Jesssullivan/cmux` (e.g. `lab-v0.75.0`) so the manifest can pin a verifiable source
+
+## 1. Local build verification (do before submitting)
+
+The manifest already lives at `flatpak/com.jesssullivan.cmux.yml`. Build it
+locally to confirm the current main branch produces a working bundle:
+
+```bash
+cd /Users/jess/git/cmux
+flatpak-builder --user --install --force-clean build-flatpak \
+  flatpak/com.jesssullivan.cmux.yml
+flatpak run com.jesssullivan.cmux
+```
+
+If that fails, fix in `flatpak/com.jesssullivan.cmux.yml` and `flatpak/dependencies.yml` *before* opening the Flathub PR. CI runs the same build via `.github/workflows/flatpak-ci.yml`; check its latest green run.
+
+## 2. Pin manifest to a release tag
+
+Flathub will not accept a manifest that builds from a moving branch. Edit
+the manifest (or maintain a Flathub-only copy at submission time) so the
+`cmux` source module references a tagged ref:
+
+```yaml
+- name: cmux
+  sources:
+    - type: git
+      url: https://github.com/Jesssullivan/cmux.git
+      tag: lab-v0.75.0   # bump on every release
+      commit: <sha>      # optional but Flathub-preferred
+```
+
+Same for the `ghostty` submodule source if it is fetched separately.
+
+## 3. Fork and PR against `flathub/flathub`
+
+The submission flow uses the `flathub/flathub` repo's submission process,
+not the per-app repo (which Flathub creates *after* acceptance):
+
+1. Read <https://github.com/flathub/flathub/wiki/App-Submission>
+2. `gh repo fork flathub/flathub --clone --remote`
+3. `cd flathub && git checkout -b new-pr/com.jesssullivan.cmux`
+4. Copy the pinned manifest in as `com.jesssullivan.cmux.yml`
+5. Add a `flathub.json` if needed (allow extra sources, baseapps, etc.)
+6. Commit and push to your fork
+7. Open a PR titled `Add com.jesssullivan.cmux` against `flathub/flathub:new-pr`
+8. Address reviewer feedback (the Flathub buildbot runs `flatpak-builder` on every push)
+
+## 4. Post-acceptance: manage `flathub/com.jesssullivan.cmux`
+
+Once accepted, Flathub creates `flathub/com.jesssullivan.cmux`. You are
+added as a maintainer. From then on, version bumps are PRs against that
+per-app repo:
+
+1. `gh repo clone flathub/com.jesssullivan.cmux`
+2. Edit the `tag:` and `commit:` fields in `com.jesssullivan.cmux.yml`
+3. PR. The Flathub buildbot will build, then a human reviewer will merge.
+
+## 5. Wire auto-PR on cmux release (later, optional)
+
+Add a workflow under `.github/workflows/flathub-bump.yml` in
+`Jesssullivan/cmux` that, on tag push, opens a PR against the per-app
+Flathub repo using a PAT. Keep this gated behind a manual `workflow_dispatch`
+until the cadence is stable.
+
+## QA checklist before submission
+
+- [ ] Local `flatpak-builder ... && flatpak run` works end-to-end
+- [ ] `flatpak-ci.yml` is green on `main`
+- [ ] Manifest pins to a tag (not a branch)
+- [ ] AppStream metainfo at `dist/linux/com.jesssullivan.cmux.metainfo.xml` validates: `appstreamcli validate dist/linux/com.jesssullivan.cmux.metainfo.xml`
+- [ ] Desktop file validates: `desktop-file-validate dist/linux/com.jesssullivan.cmux.desktop`
+- [ ] Icons exist at 16/128/256/512 px (already in `dist/linux/icons/`)
+- [ ] `finish-args` lists are minimal and justified (current set is OK)
+- [ ] License is correct in metainfo (currently `MIT`)
+- [ ] `developer_name`, `summary`, and `description` in metainfo read well
+
+## Reference links
+
+- Submission docs: <https://docs.flathub.org/docs/for-app-authors/submission>
+- Manifest reference: <https://docs.flatpak.org/en/latest/manifests.html>
+- finish-args reference: <https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html>
+
+## Linear
+
+- Project: cmux/C — Distribution Surfaces (`TIN-179`)
+- Initiative: cmux Linux Distribution & Tech Debt Reset

--- a/docs/release/homebrew.md
+++ b/docs/release/homebrew.md
@@ -1,0 +1,106 @@
+# Homebrew Cask bump runbook
+
+This is a **human-driven** runbook. The cask repo lives at
+`manaflow-ai/homebrew-cmux`, which is upstream and intentionally
+off-limits to this fork's agent automation. Run the PR yourself.
+
+## Current state (2026-04-17)
+
+- Latest cmux stable tag: `v0.63.2`
+- Pinned cask version: `0.62.1`
+- Versions to skip past: `0.63.0`, `0.63.1`, `0.63.2`
+
+Bump straight to `0.63.2` rather than landing three sequential PRs.
+
+## 1. Derive artifact SHA256
+
+Get the macOS DMG attached to the `v0.63.2` GitHub release:
+
+```bash
+# Either download from the release URL...
+gh release download v0.63.2 --repo Jesssullivan/cmux --pattern 'cmux-macos.dmg' --dir /tmp
+shasum -a 256 /tmp/cmux-macos.dmg
+# ...or use the asset URL the cask already references and compute remotely:
+curl -sL "https://github.com/Jesssullivan/cmux/releases/download/v0.63.2/cmux-macos.dmg" \
+  | shasum -a 256
+```
+
+Save the resulting hash; you'll paste it into the cask.
+
+## 2. Clone and branch
+
+```bash
+gh repo clone manaflow-ai/homebrew-cmux ~/git/homebrew-cmux
+cd ~/git/homebrew-cmux
+git checkout -b bump-cmux-0.63.2
+```
+
+## 3. Edit `Casks/cmux.rb`
+
+```diff
+ cask "cmux" do
+-  version "0.62.1"
+-  sha256 "<old-sha>"
++  version "0.63.2"
++  sha256 "<new-sha-from-step-1>"
+
+   url "https://github.com/Jesssullivan/cmux/releases/download/v#{version}/cmux-macos.dmg"
+   ...
+ end
+```
+
+(If the cask already uses a `livecheck` block, no other changes needed.)
+
+## 4. Local validate
+
+```bash
+brew style --fix Casks/cmux.rb
+brew audit --new --strict --online Casks/cmux.rb
+brew install --cask --force ./Casks/cmux.rb
+brew uninstall --cask cmux  # cleanup after smoke test
+```
+
+## 5. Commit + PR
+
+```bash
+git add Casks/cmux.rb
+git commit -m "cmux: bump to 0.63.2"
+git push -u origin bump-cmux-0.63.2
+gh pr create --repo manaflow-ai/homebrew-cmux \
+  --title "cmux: bump to 0.63.2" \
+  --body "$(cat <<'EOF'
+Bump cmux cask to v0.63.2.
+
+Skips 0.63.0 and 0.63.1 — cask is currently 3 versions stale (last bump 0.62.1).
+
+## Verification
+- [x] \`brew audit --new --strict --online Casks/cmux.rb\` clean
+- [x] Local install + launch smoke test
+- [x] SHA256 verified against the GitHub release artifact
+
+Source release: https://github.com/Jesssullivan/cmux/releases/tag/v0.63.2
+EOF
+)"
+```
+
+## 6. After merge
+
+Verify a fresh tap install pulls the new version:
+
+```bash
+brew untap manaflow-ai/cmux 2>/dev/null
+brew tap manaflow-ai/cmux
+brew install --cask cmux
+brew info --cask cmux | head -5  # should show 0.63.2
+```
+
+## Future automation (not in scope for this bump)
+
+Add a workflow in `Jesssullivan/cmux` that opens a homebrew PR on every
+stable tag. Gate behind `workflow_dispatch` until cadence is stable.
+Lives under `.github/workflows/homebrew-bump.yml` if added.
+
+## Linear
+
+- Project: cmux/C — Distribution Surfaces (`TIN-180`)
+- Initiative: cmux Linux Distribution & Tech Debt Reset


### PR DESCRIPTION
## Summary

Adds two operator-facing runbooks under `docs/release/`:

- **`flathub.md`** — first-time submission flow against `flathub/flathub`, then per-app-repo (`flathub/com.jesssullivan.cmux`) version bumps. Includes the local `flatpak-builder` smoke test, manifest-pin pattern, finish-args/metainfo QA checklist, and pointer to the future `flathub-bump.yml` automation slot.
- **`homebrew.md`** — cask version bump for `manaflow-ai/homebrew-cmux`, scoped to the current 0.62.1 → 0.63.2 jump (skips the intermediate 0.63.0 / 0.63.1). Covers SHA256 derivation from the GitHub release, `brew style/audit/install` validation, PR template, and post-merge tap verification.

Both runbooks are explicitly **human-driven**: they document repos this fork's agent automation is not allowed to push to (Flathub orgs and `manaflow-ai/*` are off-limits per project policy). The docs let the human operator execute these flows without re-deriving the steps each release.

Companion to PR #215 (which adds `docs/release/SIGNING.md`) — together they cover the three release surfaces: signing, Flathub, and Homebrew.

## Test plan

- [x] Markdown links verified manually
- [x] Step ordering matches the actual fork/branch/PR flow used last release
- [x] Commands quoted as runnable shell snippets (no placeholder paths beyond `~/git/...`)
- [x] No off-limits repo write paths (manaflow-ai, flathub) — only fetch/clone/fork

Refs: TIN-179