### PR TITLE
linux(socket): add auth.login as no-op gate (Sprint A #4)

### DIFF
--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -192,6 +192,7 @@ const methods = .{
     .{ "system.version", handleVersion },
     .{ "system.identify", handleIdentify },
     .{ "system.capabilities", handleCapabilities },
+    .{ "auth.login", handleAuthLogin },
     .{ "window.list", handleWindowList },
     .{ "window.current", handleWindowCurrent },
     .{ "workspace.list", handleWorkspaceList },
@@ -546,6 +547,15 @@ fn handleIdentify(alloc: Allocator, _: json.Value) []const u8 {
 
 fn handleCapabilities(_: Allocator, _: json.Value) []const u8 {
     return "{\"workspaces\":true,\"splits\":true,\"notifications\":true,\"browser\":true,\"session\":true}";
+}
+
+fn handleAuthLogin(_: Allocator, _: json.Value) []const u8 {
+    // The Linux build does not gate the v2 socket behind a password.
+    // Match the macOS response shape: {authenticated, required}. We always
+    // report authenticated=true so existing v1/v2 clients short-circuit the
+    // password handshake gracefully, and required=false so they know the
+    // gate is not enforced on this platform.
+    return "{\"authenticated\":true,\"required\":false}";
 }
 
 // ── Window Handlers ─────────────────────────────────────────────────────

--- a/tests_v2/test_auth_login.py
+++ b/tests_v2/test_auth_login.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Socket API: auth.login round-trip on Linux.
+
+The Linux build does not gate the v2 socket behind a password — there is no
+keychain/credential store wired up yet. We still implement auth.login so that
+the v2 protocol surface matches macOS: clients that probe the gate get a
+deterministic {authenticated:true, required:false} reply instead of
+method_not_found, and v1 password handshakes degrade gracefully.
+
+This test exercises three angles:
+  1. No-params call returns the canonical shape.
+  2. Unknown params (password=anything) are accepted, not rejected.
+  3. Repeated calls remain idempotent and never trigger an auth_required gate.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _assert_shape(label: str, res) -> None:
+    if not isinstance(res, dict):
+        raise cmuxError(f"{label}: expected dict, got {type(res).__name__}: {res!r}")
+    if res.get("authenticated") is not True:
+        raise cmuxError(f"{label}: expected authenticated=true, got {res!r}")
+    if res.get("required") is not False:
+        raise cmuxError(f"{label}: expected required=false, got {res!r}")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        # 1) No params at all — server must accept.
+        res = c._call("auth.login")
+        _assert_shape("auth.login (no params)", res)
+
+        # 2) Spurious password params should not break the no-op gate.
+        res = c._call("auth.login", {"password": "ignored-on-linux"})
+        _assert_shape("auth.login (password param)", res)
+
+        # 3) Re-calling auth.login is safe and idempotent — no auth_required
+        #    error and shape is stable across calls.
+        res = c._call("auth.login", {})
+        _assert_shape("auth.login (empty params)", res)
+
+        # 4) Other RPCs continue to work without an auth handshake — the gate
+        #    must not be implicitly enabled by any of the calls above.
+        ping = c._call("system.ping")
+        if not isinstance(ping, dict) or ping.get("pong") is not True:
+            raise cmuxError(f"system.ping after auth.login failed: {ping!r}")
+
+    print("PASS: auth.login (no-op gate, idempotent, shape stable)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `auth.login` to the Linux v2 socket dispatch table.
- Returns a constant `{authenticated:true, required:false}` matching the macOS response shape.
- Adds a socket round-trip test (`tests_v2/test_auth_login.py`) covering no-params, spurious password params, idempotency, and a follow-up `system.ping` to assert no implicit gate is engaged.

The macOS build supports an optional password handshake (`SocketControlPasswordStore`); the Linux build does not yet wire any credential store. Implementing `auth.login` as a deterministic no-op closes one of the lowest-effort gaps from the Phase 3 parity audit so v1/v2 clients that probe the gate get the expected reply instead of `method_not_found`.

## Sprint context

- Tracker: TIN-183 follow-up after #218
- Issue: #220 — Phase 3 candidate list, Sprint A item #4
- Unblocks: `test_system_api.py` (already partially passing) and any downstream client that probes the gate before issuing v2 calls
- After merge: dispatch table goes from 65 → 66 methods; macOS-only gap shrinks from 95 → 94

## Test plan

- [x] Local: `git diff --stat` confirms surgical change (10 LOC + new test).
- [ ] CI: Socket Tests workflow on `sid/socket-auth-login` runs `tests_v2/test_auth_login.py` and the existing `tests_v2/test_system_api.py` against a freshly-built `cmux-linux` daemon.
- [ ] CI: Ensure none of the existing 14 passing tests regress.

## Related

- #218 (`surface.action`) — preceding parity PR
- #221 (`workspace.action`) — Sprint A item #1, in flight
- #216 — Phase 2 parity audit