### PR TITLE
linux(socket): add system.tree composing window/workspace/pane/surface (Sprint A #5)

### DIFF
--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -193,6 +193,7 @@ const methods = .{
     .{ "system.identify", handleIdentify },
     .{ "system.capabilities", handleCapabilities },
     .{ "auth.login", handleAuthLogin },
+    .{ "system.tree", handleSystemTree },
     .{ "window.list", handleWindowList },
     .{ "window.current", handleWindowCurrent },
     .{ "workspace.list", handleWorkspaceList },
@@ -570,6 +571,161 @@ fn handleAuthLogin(_: Allocator, _: json.Value) []const u8 {
     // password handshake gracefully, and required=false so they know the
     // gate is not enforced on this platform.
     return "{\"authenticated\":true,\"required\":false}";
+}
+
+/// Compose a window→workspace→pane→surface tree mirroring the macOS shape.
+///
+/// Linux currently uses a 1:1 panel:pane mapping (no pane grouping yet), so
+/// each pane node always contains exactly one surface and `pane_id` /
+/// `surface_id` resolve to the same underlying panel UUID. Any client that
+/// joins/breaks panes on Linux later will get richer pane/surface arrays
+/// without changing this shape.
+///
+/// Optional params recognised today:
+///   - none (workspace_id / all_windows / caller filters from macOS are not
+///     yet implemented; the tree always covers every known window).
+fn handleSystemTree(alloc: Allocator, params: json.Value) []const u8 {
+    _ = params;
+    const empty = "{\"active\":{},\"windows\":[]}";
+    const tm = getTabManager() orelse return empty;
+    ensureDefaultWindow();
+
+    const selected_ws = tm.selectedWorkspace();
+
+    var buf: std.ArrayList(u8) = .empty;
+    const w = buf.writer(alloc);
+
+    // ── active focus pointer (matches handleIdentify shape) ──
+    w.writeAll("{\"active\":") catch return empty;
+    if (selected_ws) |ws| {
+        const ws_hex = formatId(ws.id);
+        w.writeAll("{\"workspace_id\":\"") catch return empty;
+        w.writeAll(&ws_hex) catch return empty;
+        w.writeAll("\"") catch return empty;
+        if (ws.focused_panel_id) |pid| {
+            const pid_hex = formatId(pid);
+            w.writeAll(",\"surface_id\":\"") catch return empty;
+            w.writeAll(&pid_hex) catch return empty;
+            w.writeAll("\"") catch return empty;
+        }
+        for (window_store[0..window_count]) |win_entry| {
+            if (win_entry.hasWorkspace(ws.id)) {
+                const win_hex = formatId(win_entry.id);
+                w.writeAll(",\"window_id\":\"") catch return empty;
+                w.writeAll(&win_hex) catch return empty;
+                w.writeAll("\"") catch return empty;
+                break;
+            }
+        }
+        w.writeAll("}") catch return empty;
+    } else {
+        w.writeAll("{}") catch return empty;
+    }
+
+    // ── windows[] ──
+    w.writeAll(",\"windows\":[") catch return empty;
+    for (window_store[0..window_count], 0..) |win_entry, win_idx| {
+        if (win_idx > 0) w.writeAll(",") catch {};
+        const win_hex = formatId(win_entry.id);
+
+        // Count workspaces in this window and find the selected one (if any).
+        var ws_in_window: usize = 0;
+        var sel_ws_in_window: ?u128 = null;
+        for (tm.workspaces.items) |ws| {
+            if (!win_entry.hasWorkspace(ws.id)) continue;
+            ws_in_window += 1;
+            if (selected_ws) |sws| {
+                if (sws.id == ws.id) sel_ws_in_window = ws.id;
+            }
+        }
+
+        w.writeAll("{\"id\":\"") catch return empty;
+        w.writeAll(&win_hex) catch return empty;
+        w.print(
+            "\",\"ref\":\"window:{d}\",\"index\":{d},\"workspace_count\":{d},\"selected_workspace_id\":",
+            .{ win_idx, win_idx, ws_in_window },
+        ) catch return empty;
+        if (sel_ws_in_window) |sid| {
+            const sid_hex = formatId(sid);
+            w.writeAll("\"") catch return empty;
+            w.writeAll(&sid_hex) catch return empty;
+            w.writeAll("\"") catch return empty;
+        } else {
+            w.writeAll("null") catch return empty;
+        }
+        w.writeAll(",\"workspaces\":[") catch return empty;
+
+        // ── workspaces[] (filtered to this window) ──
+        var ws_out_idx: usize = 0;
+        for (tm.workspaces.items) |ws| {
+            if (!win_entry.hasWorkspace(ws.id)) continue;
+            if (ws_out_idx > 0) w.writeAll(",") catch {};
+            const ws_hex = formatId(ws.id);
+            const is_ws_selected = if (selected_ws) |sws| sws.id == ws.id else false;
+
+            w.writeAll("{\"id\":\"") catch return empty;
+            w.writeAll(&ws_hex) catch return empty;
+            w.print(
+                "\",\"ref\":\"workspace:{d}\",\"index\":{d},\"title\":",
+                .{ ws_out_idx, ws_out_idx },
+            ) catch return empty;
+            writeJsonString(w, ws.displayTitle()) catch return empty;
+            w.print(
+                ",\"selected\":{s},\"pinned\":{s},\"panes\":[",
+                .{
+                    if (is_ws_selected) "true" else "false",
+                    if (ws.is_pinned) "true" else "false",
+                },
+            ) catch return empty;
+
+            // ── panes[] (Linux: one pane per panel) ──
+            for (ws.ordered_panels.items, 0..) |panel_id, p_idx| {
+                const panel = ws.panels.get(panel_id) orelse continue;
+                if (p_idx > 0) w.writeAll(",") catch {};
+                const panel_hex = formatId(panel.id);
+                const is_focused = if (ws.focused_panel_id) |fid| fid == panel.id else false;
+                const focused_str: []const u8 = if (is_focused) "true" else "false";
+                const title_str = panel.custom_title orelse panel.title orelse "Terminal";
+                const type_str = @tagName(panel.panel_type);
+
+                // Pane node — surface_count is always 1 on Linux today.
+                w.writeAll("{\"id\":\"") catch return empty;
+                w.writeAll(&panel_hex) catch return empty;
+                w.print(
+                    "\",\"ref\":\"pane:{d}\",\"index\":{d},\"focused\":{s},\"surface_count\":1,\"selected_surface_id\":\"",
+                    .{ p_idx, p_idx, focused_str },
+                ) catch return empty;
+                w.writeAll(&panel_hex) catch return empty;
+                w.print(
+                    "\",\"selected_surface_ref\":\"surface:{d}\",\"surfaces\":[",
+                    .{p_idx},
+                ) catch return empty;
+
+                // Single surface entry per pane.
+                w.writeAll("{\"id\":\"") catch return empty;
+                w.writeAll(&panel_hex) catch return empty;
+                w.print(
+                    "\",\"ref\":\"surface:{d}\",\"index\":{d},\"index_in_pane\":0,\"type\":\"{s}\",\"focused\":{s},\"selected\":true,\"selected_in_pane\":true,\"pane_id\":\"",
+                    .{ p_idx, p_idx, type_str, focused_str },
+                ) catch return empty;
+                w.writeAll(&panel_hex) catch return empty;
+                w.print(
+                    "\",\"pane_ref\":\"pane:{d}\",\"title\":",
+                    .{p_idx},
+                ) catch return empty;
+                writeJsonString(w, title_str) catch return empty;
+                w.writeAll("}]}") catch return empty; // close surface + surfaces[] + pane
+            }
+
+            w.writeAll("]}") catch return empty; // close panes[] + workspace
+            ws_out_idx += 1;
+        }
+
+        w.writeAll("]}") catch return empty; // close workspaces[] + window
+    }
+    w.writeAll("]}") catch return empty; // close windows[] + root
+
+    return buf.toOwnedSlice(alloc) catch empty;
 }
 
 // ── Window Handlers ─────────────────────────────────────────────────────

--- a/tests_v2/test_system_tree.py
+++ b/tests_v2/test_system_tree.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Socket API: system.tree on Linux.
+
+Asserts that the tree composes existing window/workspace/surface state into
+the macOS-shaped { active, windows[].workspaces[].panes[].surfaces[] }
+envelope. Linux currently uses 1:1 panel:pane mapping, so every pane carries
+exactly one surface and the pane_id/surface_id of that pair are identical.
+
+This test creates an extra workspace so the tree contains more than the
+default workspace, and (best-effort) re-selects the original to leave the
+session unchanged on exit.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _is_uuid_hex(s: object) -> bool:
+    return isinstance(s, str) and len(s) == 32 and all(ch in "0123456789abcdef" for ch in s)
+
+
+def _assert_window_node(node: dict) -> None:
+    if not _is_uuid_hex(node.get("id")):
+        raise cmuxError(f"window.id not a 32-char hex: {node!r}")
+    if not isinstance(node.get("ref"), str) or not node["ref"].startswith("window:"):
+        raise cmuxError(f"window.ref not 'window:N': {node!r}")
+    if not isinstance(node.get("index"), int):
+        raise cmuxError(f"window.index missing/not int: {node!r}")
+    if not isinstance(node.get("workspace_count"), int):
+        raise cmuxError(f"window.workspace_count missing/not int: {node!r}")
+    workspaces = node.get("workspaces")
+    if not isinstance(workspaces, list):
+        raise cmuxError(f"window.workspaces not a list: {node!r}")
+    if len(workspaces) != node["workspace_count"]:
+        raise cmuxError(
+            f"window.workspace_count={node['workspace_count']} but len(workspaces)={len(workspaces)}"
+        )
+
+
+def _assert_workspace_node(node: dict, expected_index: int) -> None:
+    if not _is_uuid_hex(node.get("id")):
+        raise cmuxError(f"workspace.id not hex: {node!r}")
+    if node.get("ref") != f"workspace:{expected_index}":
+        raise cmuxError(f"workspace.ref expected 'workspace:{expected_index}', got {node!r}")
+    if node.get("index") != expected_index:
+        raise cmuxError(f"workspace.index expected {expected_index}, got {node!r}")
+    if not isinstance(node.get("title"), str):
+        raise cmuxError(f"workspace.title not string: {node!r}")
+    if not isinstance(node.get("selected"), bool):
+        raise cmuxError(f"workspace.selected not bool: {node!r}")
+    if not isinstance(node.get("pinned"), bool):
+        raise cmuxError(f"workspace.pinned not bool: {node!r}")
+    panes = node.get("panes")
+    if not isinstance(panes, list):
+        raise cmuxError(f"workspace.panes not list: {node!r}")
+
+
+def _assert_pane_node(node: dict, expected_index: int) -> None:
+    if not _is_uuid_hex(node.get("id")):
+        raise cmuxError(f"pane.id not hex: {node!r}")
+    if node.get("ref") != f"pane:{expected_index}":
+        raise cmuxError(f"pane.ref expected 'pane:{expected_index}', got {node!r}")
+    if node.get("index") != expected_index:
+        raise cmuxError(f"pane.index expected {expected_index}, got {node!r}")
+    if node.get("surface_count") != 1:
+        raise cmuxError(f"pane.surface_count expected 1 on Linux 1:1 mapping, got {node!r}")
+    if node.get("selected_surface_id") != node.get("id"):
+        raise cmuxError(f"pane.selected_surface_id should equal pane.id on Linux: {node!r}")
+    surfaces = node.get("surfaces")
+    if not isinstance(surfaces, list) or len(surfaces) != 1:
+        raise cmuxError(f"pane.surfaces should have exactly one entry on Linux: {node!r}")
+
+
+def _assert_surface_node(node: dict, expected_pane_id: str, expected_pane_index: int) -> None:
+    if node.get("id") != expected_pane_id:
+        raise cmuxError(f"surface.id should equal pane.id on Linux 1:1: {node!r}")
+    if node.get("pane_id") != expected_pane_id:
+        raise cmuxError(f"surface.pane_id should equal owning pane.id: {node!r}")
+    if node.get("ref") != f"surface:{expected_pane_index}":
+        raise cmuxError(f"surface.ref expected 'surface:{expected_pane_index}', got {node!r}")
+    if node.get("pane_ref") != f"pane:{expected_pane_index}":
+        raise cmuxError(f"surface.pane_ref expected 'pane:{expected_pane_index}', got {node!r}")
+    if node.get("index_in_pane") != 0:
+        raise cmuxError(f"surface.index_in_pane should be 0 on Linux 1:1: {node!r}")
+    if node.get("type") not in {"terminal", "browser", "markdown"}:
+        raise cmuxError(f"surface.type unexpected: {node!r}")
+    for key in ("focused", "selected", "selected_in_pane"):
+        if not isinstance(node.get(key), bool):
+            raise cmuxError(f"surface.{key} should be bool: {node!r}")
+    if not isinstance(node.get("title"), str):
+        raise cmuxError(f"surface.title should be string: {node!r}")
+
+
+def _run(c: cmux) -> None:
+    initial_workspace = c.current_workspace()
+    if not _is_uuid_hex(initial_workspace):
+        raise cmuxError(f"current_workspace returned non-hex id: {initial_workspace!r}")
+
+    res = c._call("system.tree")
+    if not isinstance(res, dict):
+        raise cmuxError(f"system.tree expected dict, got {type(res).__name__}: {res!r}")
+
+    active = res.get("active")
+    if not isinstance(active, dict):
+        raise cmuxError(f"system.tree.active not a dict: {active!r}")
+    if active.get("workspace_id") != initial_workspace:
+        raise cmuxError(
+            f"active.workspace_id={active.get('workspace_id')!r} mismatched current={initial_workspace!r}"
+        )
+
+    windows = res.get("windows")
+    if not isinstance(windows, list) or not windows:
+        raise cmuxError(f"system.tree.windows must be non-empty list: {windows!r}")
+
+    found_initial_in_tree = False
+    for window in windows:
+        _assert_window_node(window)
+        for ws_idx, ws in enumerate(window["workspaces"]):
+            _assert_workspace_node(ws, ws_idx)
+            if ws["id"] == initial_workspace:
+                found_initial_in_tree = True
+            for pane_idx, pane in enumerate(ws["panes"]):
+                _assert_pane_node(pane, pane_idx)
+                for surface in pane["surfaces"]:
+                    _assert_surface_node(surface, pane["id"], pane_idx)
+
+    if not found_initial_in_tree:
+        raise cmuxError(
+            f"current workspace {initial_workspace!r} not present in any window in the tree"
+        )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        # Snapshot the original selected workspace so we can restore it.
+        try:
+            baseline = c.current_workspace()
+        except cmuxError:
+            baseline = None
+
+        # Add a second workspace so the tree exercises a multi-workspace shape.
+        created = c.new_workspace()
+
+        try:
+            _run(c)
+        finally:
+            if baseline:
+                try:
+                    c.select_workspace(baseline)
+                except Exception:
+                    pass
+            if created:
+                try:
+                    c.close_workspace(created)
+                except Exception:
+                    pass
+
+    print("PASS: system.tree (active pointer, window/workspace/pane/surface composition)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `system.tree` to the Linux v2 socket dispatch, mirroring the macOS response shape.
- Composes `window.list` + `workspace.list` + `pane.list` + `surface.list` into a single envelope so CLIs / status-bar clients don't need N+1 round-trips.
- Exploits Linux's current 1:1 panel:pane mapping: every pane has exactly one surface, and \`pane.id == surface.id\` for that pair. The shape leaves room for future pane grouping without breaking clients.
- Adds a socket round-trip test exercising structure, refs, focus pointer, and the 1:1 invariant. Test creates an extra workspace, restores baseline selection, and tears down in a \`finally\` block.

## Tree shape

\`\`\`
active: { workspace_id, surface_id, window_id }   // matches system.identify
windows[]: {
  id, ref, index, workspace_count, selected_workspace_id,
  workspaces[]: {
    id, ref, index, title, selected, pinned,
    panes[]: {
      id, ref, index, focused, surface_count, selected_surface_id, selected_surface_ref,
      surfaces[]: {
        id, ref, index, index_in_pane, type, focused, selected, selected_in_pane,
        pane_id, pane_ref, title
      }
    }
  }
}
\`\`\`

Optional macOS params (\`workspace_id\`, \`all_windows\`, \`caller\`) are not yet implemented; tree always covers every known window. Filed as a follow-up note in the docstring.

## Sprint context

- Tracker: TIN-183 follow-up after #218
- Issue: #220 — Phase 3 candidate list, Sprint A item #5
- Builds atop: #221 (\`workspace.action\`), #222 (\`auth.login\`)
- Dispatch table: 65 → 66 methods on this branch alone (and 67 once #222 lands).

## Test plan

- [x] Local: \`git diff --stat\` confirms surgical change (one new function + one test).
- [ ] CI: Socket Tests workflow on \`sid/socket-system-tree\` runs \`tests_v2/test_system_tree.py\`.
- [ ] CI: Verify no regression in the existing 14 passing tests.

## Future work

- Implement \`workspace_id\`, \`all_windows\`, \`caller\` filters once a use case appears.
- Update tree shape if/when Linux adds pane grouping (\`pane.join\` / \`pane.break\`).

## Related

- #218 (\`surface.action\`) — preceding parity PR
- #221 (\`workspace.action\`) — Sprint A item #1
- #222 (\`auth.login\`) — Sprint A item #4