### PR TITLE
linux(socket): add app.simulate_active no-op stub (Sprint A #7)

### DIFF
--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -250,6 +250,7 @@ const methods = .{
     .{ "notification.list", handleNotificationList },
     .{ "notification.clear", handleNotificationClear },
     .{ "app.focus_override.set", handleAppFocusOverrideSet },
+    .{ "app.simulate_active", handleAppSimulateActive },
     .{ "debug.app.activate", handleDebugAppActivate },
     .{ "debug.flash.count", handleDebugFlashCount },
     .{ "debug.flash.reset", handleDebugFlashReset },
@@ -1808,6 +1809,15 @@ fn handleAppFocusOverrideSet(_: Allocator, params: json.Value) []const u8 {
 
 fn handleDebugAppActivate(_: Allocator, _: json.Value) []const u8 {
     // No-op on Linux (macOS activates NSApp)
+    return "{}";
+}
+
+fn handleAppSimulateActive(_: Allocator, _: json.Value) []const u8 {
+    // No-op on Linux. The macOS handler triggers
+    // applicationDidBecomeActive on NSApp so test harnesses can drive
+    // focus-restoration code paths. The Linux build has no equivalent
+    // app-active lifecycle, so we accept the call and return success
+    // to keep cross-platform tests happy.
     return "{}";
 }
 

--- a/tests_v2/test_app_simulate_active.py
+++ b/tests_v2/test_app_simulate_active.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Socket API: app.simulate_active is accepted as a no-op on Linux.
+
+The macOS implementation triggers applicationDidBecomeActive on NSApp so
+test harnesses can drive focus-restoration code paths. Linux has no
+equivalent app-active lifecycle, so we just accept the call and return
+{}, letting cross-platform tests run unmodified.
+
+This test verifies:
+  1. app.simulate_active returns an empty-object result
+  2. Repeated calls remain idempotent
+  3. Spurious params are accepted (forward-compat with macOS additions)
+  4. A subsequent system.ping still works (the call did not poison state)
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        for attempt in range(3):
+            res = c._call("app.simulate_active")
+            if res != {}:
+                raise cmuxError(
+                    f"attempt {attempt}: expected empty-object result, got {res!r}"
+                )
+
+        # Spurious params should be ignored, not rejected
+        res2 = c._call(
+            "app.simulate_active",
+            {"window_id": "ignored", "extra": True},
+        )
+        if res2 != {}:
+            raise cmuxError(f"spurious-params call returned {res2!r}")
+
+        # Daemon is still healthy after the no-op stream
+        ping = c._call("system.ping")
+        if not isinstance(ping, dict):
+            raise cmuxError(f"system.ping after simulate_active returned {ping!r}")
+
+    print("PASS: app.simulate_active no-op (idempotent, ignores spurious params)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the v2 \`app.simulate_active\` RPC on Linux as an idempotent
no-op. The macOS handler triggers \`applicationDidBecomeActive\` on NSApp
so test harnesses can drive focus-restoration code paths, but Linux has
no equivalent app-active lifecycle. Returning \`{}\` lets cross-platform
clients call this method unconditionally without branching.

## What's added

- \`cmux-linux/src/socket.zig\`: \`.{ "app.simulate_active", handleAppSimulateActive }\` dispatch entry + 1-line handler returning \`"{}"\`.
- \`tests_v2/test_app_simulate_active.py\`: verifies
  - empty-object result
  - idempotency over repeated calls
  - tolerance of spurious params (forward-compat for any future macOS additions)
  - subsequent \`system.ping\` still works (daemon health gate)

## Linux vs macOS

macOS reactivates \`NSApp\` and runs \`applicationDidBecomeActive\` side
effects. Linux has no NSApp; GTK4's \`gtk_window_present_with_time\`
plays a different role and isn't called by any v2 client today, so the
handler intentionally does nothing rather than guess. If/when Linux
needs a focus-simulation hook, it should ship under a more specific
name (e.g. \`window.activate\`).

## Test plan

- [ ] Socket tests CI is green
- [ ] Distro tests CI is green
- [ ] \`nix develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast'\`

Refs #220 (Sprint A item #7).