### PR TITLE
linux(socket): add notification.create_for_target (Sprint A #6)

### DIFF
--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -247,6 +247,7 @@ const methods = .{
     .{ "browser.find_finish", if (c.has_webkit) handleBrowserFindFinish else handleBrowserUnavailable },
     .{ "notification.create", handleNotificationCreate },
     .{ "notification.create_for_surface", handleNotificationCreateForSurface },
+    .{ "notification.create_for_target", handleNotificationCreateForTarget },
     .{ "notification.list", handleNotificationList },
     .{ "notification.clear", handleNotificationClear },
     .{ "app.focus_override.set", handleAppFocusOverrideSet },
@@ -1753,6 +1754,77 @@ fn handleNotificationCreateForSurface(alloc: Allocator, params: json.Value) []co
     }
     notification_count += 1;
     return "{}";
+}
+
+fn handleNotificationCreateForTarget(alloc: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+
+    // Both ids are required. Unlike create_for_surface we do not fall
+    // back to the focused surface — the caller has explicitly named the
+    // routing target and we should fail loudly if it does not resolve.
+    const ws_id_str = getParamString(params, "workspace_id") orelse
+        return "{\"error\":\"missing workspace_id\"}";
+    const sid_str = getParamString(params, "surface_id") orelse
+        return "{\"error\":\"missing surface_id\"}";
+
+    const ws_lookup = findWorkspaceById(tm, ws_id_str) orelse
+        return "{\"error\":\"invalid workspace_id\"}";
+    const ws = ws_lookup.ws;
+
+    const target_id = findSurfaceInWorkspace(ws, sid_str) orelse
+        return "{\"error\":\"invalid surface_id\"}";
+
+    const title = getParamString(params, "title") orelse "Notification";
+    // Optional fields. We accept `subtitle` for cross-platform parity but
+    // do not yet have a slot for it in StoredNotification; the body is
+    // truncated to fit the fixed-size buffer.
+    _ = getParamString(params, "subtitle");
+    const body_opt = getParamString(params, "body");
+
+    // Suppress only if the app is reporting itself focused AND the target
+    // surface is the currently-focused surface in its workspace.
+    if (app_focus_override) |focused| {
+        if (focused) {
+            if (ws.focused_panel_id) |fid| {
+                if (fid == target_id) return "{}";
+            }
+        }
+    }
+
+    if (notification_count >= notification_store_buf.len)
+        notification_count = notification_store_buf.len - 1;
+    var notif = &notification_store_buf[notification_count];
+    notif.* = .{ .id = blk: {
+        var id_buf: [16]u8 = undefined;
+        std.crypto.random.bytes(&id_buf);
+        break :blk std.mem.readInt(u128, &id_buf, .little);
+    } };
+
+    const tlen = @min(title.len, notif.title.len);
+    @memcpy(notif.title[0..tlen], title[0..tlen]);
+    notif.title_len = tlen;
+
+    if (body_opt) |body| {
+        const blen = @min(body.len, notif.body.len);
+        @memcpy(notif.body[0..blen], body[0..blen]);
+        notif.body_len = blen;
+    }
+
+    notif.surface_id = target_id;
+    notification_count += 1;
+
+    // Flash the addressed surface so list views surface the unread state
+    if (ws.panels.getPtr(target_id)) |panel_ptr| {
+        panel_ptr.*.flash_count += 1;
+    }
+
+    const ws_hex = formatId(ws.id);
+    const sid_hex = formatId(target_id);
+    return std.fmt.allocPrint(
+        alloc,
+        "{{\"workspace_id\":\"{s}\",\"surface_id\":\"{s}\"}}",
+        .{ @as([]const u8, &ws_hex), @as([]const u8, &sid_hex) },
+    ) catch "{}";
 }
 
 fn handleNotificationList(alloc: Allocator, _: json.Value) []const u8 {

--- a/tests_v2/test_notification_create_for_target.py
+++ b/tests_v2/test_notification_create_for_target.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Socket API: notification.create_for_target requires both ids and routes correctly.
+
+Linux's create_for_target is the strict variant of create_for_surface:
+both workspace_id and surface_id are required, and the surface must
+belong to the workspace. Successful calls add a flash to the surface
+and append to the in-memory notification store.
+
+This test verifies:
+  1. Successful call with valid ids returns {workspace_id, surface_id}
+  2. Notification appears in notification.list with the right surface_id
+  3. Repeated calls increment notification.list count
+  4. Missing workspace_id / surface_id -> error
+  5. Invalid workspace_id / surface_id -> error
+  6. Spurious title/subtitle/body params accepted
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _expect_error(label: str, fn) -> None:
+    try:
+        fn()
+    except cmuxError:
+        return
+    raise cmuxError(f"{label}: expected error, call returned successfully")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        ws_id = c.new_workspace()
+        c.select_workspace(ws_id)
+        time.sleep(0.1)
+
+        surfaces = c.list_surfaces()
+        if not surfaces:
+            raise cmuxError("Expected at least one surface in fresh workspace")
+        focused = next((s for s in surfaces if s[2]), None)
+        if focused is None:
+            raise cmuxError("No focused surface in fresh workspace")
+        focused_id = focused[1]
+
+        # Baseline notification count
+        before = c._call("notification.list") or {}
+        before_n = len(before.get("notifications", []))
+
+        # 1. Successful call
+        res = c._call(
+            "notification.create_for_target",
+            {
+                "workspace_id": ws_id,
+                "surface_id": focused_id,
+                "title": "Build done",
+                "subtitle": "macOS-shape param accepted",
+                "body": "All green",
+            },
+        )
+        if not isinstance(res, dict):
+            raise cmuxError(f"create_for_target returned {res!r}")
+        if res.get("workspace_id") != ws_id:
+            raise cmuxError(f"workspace_id echo mismatch: {res!r}")
+        if res.get("surface_id") != focused_id:
+            raise cmuxError(f"surface_id echo mismatch: {res!r}")
+
+        # 2. Notification recorded with correct surface_id
+        after = c._call("notification.list") or {}
+        after_list = after.get("notifications", [])
+        if len(after_list) != before_n + 1:
+            raise cmuxError(
+                f"expected notification count {before_n + 1}, got {len(after_list)}"
+            )
+        last = after_list[-1]
+        if last.get("surface_id") != focused_id:
+            raise cmuxError(f"notification surface_id mismatch: {last!r}")
+
+        # 3. Repeated calls accumulate
+        c._call(
+            "notification.create_for_target",
+            {"workspace_id": ws_id, "surface_id": focused_id, "title": "Second"},
+        )
+        again = c._call("notification.list") or {}
+        if len(again.get("notifications", [])) != before_n + 2:
+            raise cmuxError(
+                f"expected notification count {before_n + 2} after second, got {len(again['notifications'])}"
+            )
+
+        # 4. Missing ids -> error
+        _expect_error(
+            "missing workspace_id",
+            lambda: c._call(
+                "notification.create_for_target",
+                {"surface_id": focused_id, "title": "No ws"},
+            ),
+        )
+        _expect_error(
+            "missing surface_id",
+            lambda: c._call(
+                "notification.create_for_target",
+                {"workspace_id": ws_id, "title": "No surface"},
+            ),
+        )
+
+        # 5. Invalid ids -> error
+        _expect_error(
+            "invalid workspace_id",
+            lambda: c._call(
+                "notification.create_for_target",
+                {
+                    "workspace_id": "0" * 32,
+                    "surface_id": focused_id,
+                    "title": "Bad ws",
+                },
+            ),
+        )
+        _expect_error(
+            "invalid surface_id",
+            lambda: c._call(
+                "notification.create_for_target",
+                {
+                    "workspace_id": ws_id,
+                    "surface_id": "0" * 32,
+                    "title": "Bad surface",
+                },
+            ),
+        )
+
+        # Cleanup
+        c._call("notification.clear")
+        c.close_workspace(ws_id)
+
+    print("PASS: notification.create_for_target (success, errors, accumulation)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the v2 \`notification.create_for_target\` RPC on Linux. Unlike
\`notification.create_for_surface\` (which falls back to a globally-resolved
surface), this variant **requires both \`workspace_id\` and \`surface_id\`**
and verifies the surface belongs to the named workspace.

Suppression rules match \`create_for_surface\`: when the app reports itself
focused AND the target surface is the focused surface in its workspace,
the call is a no-op.

## What's added

- \`cmux-linux/src/socket.zig\`: \`.{ "notification.create_for_target", handleNotificationCreateForTarget }\` dispatch entry + handler (~70 LOC).
  - Stores title / body on the in-memory ring buffer, sets \`surface_id\`, increments \`flash_count\` on the addressed surface
  - Accepts macOS \`subtitle\` param for cross-platform parity (silently dropped — \`StoredNotification\` has no slot for it yet)
  - Returns \`{workspace_id, surface_id}\` echoing the resolved ids
- \`tests_v2/test_notification_create_for_target.py\` covering:
  - success case with valid ids
  - \`notification.list\` reflects the new entry with the right \`surface_id\`
  - repeated calls accumulate
  - missing / invalid \`workspace_id\` and \`surface_id\` errors
  - spurious title/subtitle/body params accepted

## Linux vs macOS

macOS returns \`{workspace_id, workspace_ref, surface_id, surface_ref, window_id, window_ref}\`.
Linux returns the \`{workspace_id, surface_id}\` core pair — \`_ref\` and
\`window_*\` are intentionally omitted because their counterparts do not
exist on Linux yet.

## Test plan

- [ ] Socket tests CI is green
- [ ] Distro tests CI is green
- [ ] \`nix develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast'\`

Refs #220 (Sprint A item #6).