### PR TITLE
linux(socket): implement pane.resize via split tree (Sprint A #3)

### DIFF
--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -1776,8 +1776,8 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
         const idx = anchor_idx orelse return "{\"error\":\"surface not in panel order\"}";
 
         // Collect IDs to remove (snapshot before mutation).
-        var to_close = std.ArrayList(u128).init(alloc);
-        defer to_close.deinit();
+        var to_close = std.ArrayList(u128).empty;
+        defer to_close.deinit(alloc);
         var skipped_pinned: usize = 0;
 
         for (ws.ordered_panels.items, 0..) |id, i| {
@@ -1798,7 +1798,7 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
                     continue;
                 }
             }
-            to_close.append(id) catch continue;
+            to_close.append(alloc, id) catch continue;
         }
 
         // Remove collected panels (split tree + panel map).

--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -231,6 +231,7 @@ const methods = .{
     .{ "pane.surfaces", handlePaneSurfaces },
     .{ "pane.last", handlePaneLast },
     .{ "pane.swap", handlePaneSwap },
+    .{ "pane.resize", handlePaneResize },
     .{ "pane.break", handlePaneBreak },
     .{ "pane.join", handlePaneJoin },
     .{ "workspace.move_to_window", handleWorkspaceMoveToWindow },
@@ -1964,6 +1965,75 @@ fn handlePaneLast(alloc: Allocator, _: json.Value) []const u8 {
     const pid = ws.focused_panel_id orelse return "{}";
     const panel_hex = formatId(pid);
     return std.fmt.allocPrint(alloc, "{{\"pane_id\":\"{s}\"}}", .{@as([]const u8, &panel_hex)}) catch "{}";
+}
+
+fn handlePaneResize(alloc: Allocator, params: json.Value) []const u8 {
+    const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
+
+    const ws = if (getParamString(params, "workspace_id")) |id_str|
+        if (findWorkspaceById(tm, id_str)) |found| found.ws else return "{\"error\":\"invalid workspace_id\"}"
+    else
+        tm.selectedWorkspace() orelse return "{\"error\":\"no workspace\"}";
+
+    const dir_str = getParamString(params, "direction") orelse
+        return "{\"error\":\"missing direction (left|right|up|down)\"}";
+
+    const amount_raw = getParamInt(params, "amount") orelse 1;
+    if (amount_raw < 1) return "{\"error\":\"amount must be >= 1\"}";
+    const amount: usize = @intCast(amount_raw);
+
+    // Map direction to split orientation + which child the pane must be in.
+    const orientation: split_tree.Orientation = if (std.mem.eql(u8, dir_str, "left") or std.mem.eql(u8, dir_str, "right"))
+        .horizontal
+    else if (std.mem.eql(u8, dir_str, "up") or std.mem.eql(u8, dir_str, "down"))
+        .vertical
+    else
+        return "{\"error\":\"direction must be left|right|up|down\"}";
+
+    // "right"/"down" → grow first child → pane in first child, increase ratio
+    // "left"/"up"    → grow second child → pane in second child, decrease ratio
+    const in_first = std.mem.eql(u8, dir_str, "right") or std.mem.eql(u8, dir_str, "down");
+
+    const target_id = if (getParamString(params, "pane_id")) |id_str|
+        findSurfaceInWorkspace(ws, id_str) orelse return "{\"error\":\"invalid pane_id\"}"
+    else
+        ws.focused_panel_id orelse return "{\"error\":\"no focused pane\"}";
+
+    const root = ws.root_node orelse return "{\"error\":\"no split tree\"}";
+
+    const split = split_tree.findResizeSplit(root, target_id, orientation, in_first) orelse
+        return std.fmt.allocPrint(
+        alloc,
+        "{{\"error\":\"no {s} split ancestor in direction {s}\"}}",
+        .{ @tagName(orientation), dir_str },
+    ) catch "{\"error\":\"no matching split\"}";
+
+    // Each unit of `amount` adjusts the ratio by 0.05 (5%).
+    const delta: f64 = @as(f64, @floatFromInt(amount)) * 0.05;
+    const sign: f64 = if (in_first) 1.0 else -1.0;
+    const requested = split.ratio + (sign * delta);
+    split.ratio = @min(@max(requested, 0.1), 0.9);
+
+    // Update the GtkPaned position in real mode.
+    if (!isNoSurface()) {
+        if (split.paned) |paned_widget| {
+            const alloc_size = if (orientation == .horizontal)
+                c.gtk.gtk_widget_get_width(paned_widget)
+            else
+                c.gtk.gtk_widget_get_height(paned_widget);
+            if (alloc_size > 0) {
+                const pos: c_int = @intFromFloat(split.ratio * @as(f64, @floatFromInt(alloc_size)));
+                c.gtk.gtk_paned_set_position(@ptrCast(@alignCast(paned_widget)), pos);
+            }
+        }
+    }
+
+    const pane_hex = formatId(target_id);
+    return std.fmt.allocPrint(
+        alloc,
+        "{{\"pane_id\":\"{s}\",\"direction\":\"{s}\",\"ratio\":{d:.4}}}",
+        .{ @as([]const u8, &pane_hex), dir_str, split.ratio },
+    ) catch "{}";
 }
 
 // ── Batch 4: Complex Structural Operations ──────────────────────────────

--- a/cmux-linux/src/split_tree.zig
+++ b/cmux-linux/src/split_tree.zig
@@ -172,6 +172,48 @@ pub fn findLeaf(node: *Node, panel_id: u128) ?*Leaf {
     };
 }
 
+/// Check whether a subtree contains a given panel.
+pub fn containsPanel(node: *const Node, panel_id: u128) bool {
+    return switch (node.*) {
+        .leaf => |leaf| leaf.panel_id == panel_id,
+        .split => |split| containsPanel(split.first, panel_id) or containsPanel(split.second, panel_id),
+    };
+}
+
+/// Find the innermost split ancestor of `panel_id` whose orientation
+/// matches `target_orientation` and where the panel is in the first
+/// child (if `in_first` is true) or the second child (if false).
+///
+/// Returns a mutable pointer to the matching Split, or null if none
+/// found. The caller can then adjust `split.ratio` to resize.
+pub fn findResizeSplit(
+    node: *Node,
+    panel_id: u128,
+    target_orientation: Orientation,
+    in_first: bool,
+) ?*Split {
+    switch (node.*) {
+        .leaf => return null,
+        .split => |*split| {
+            const in_first_child = containsPanel(split.first, panel_id);
+            if (!in_first_child and !containsPanel(split.second, panel_id))
+                return null;
+
+            // Recurse into the child that contains the panel first
+            // so innermost matches win.
+            const child = if (in_first_child) split.first else split.second;
+            if (findResizeSplit(child, panel_id, target_orientation, in_first)) |inner|
+                return inner;
+
+            // If this split matches, return it.
+            if (split.orientation == target_orientation and in_first_child == in_first)
+                return split;
+
+            return null;
+        },
+    }
+}
+
 /// Recursively destroy all nodes.
 pub fn destroy(alloc: Allocator, node: *Node) void {
     switch (node.*) {

--- a/tests_v2/test_pane_resize.py
+++ b/tests_v2/test_pane_resize.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Socket API: pane.resize adjusts split divider ratios.
+
+Verifies:
+  1. Resize right grows the first child's share (ratio increases)
+  2. Resize left grows the second child's share (ratio decreases)
+  3. Ratio is clamped to [0.1, 0.9]
+  4. Resize with custom amount steps the ratio proportionally
+  5. Error on no split (single-pane workspace)
+  6. Error on bad direction
+  7. Error on no matching split ancestor for the given direction
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _expect_error(label: str, fn) -> None:
+    try:
+        fn()
+    except cmuxError:
+        return
+    raise cmuxError(f"{label}: expected error, got success")
+
+
+def main() -> int:
+    ws = None
+    with cmux(SOCKET_PATH) as c:
+        try:
+            ws = c.new_workspace()
+            c.select_workspace(ws)
+            time.sleep(0.1)
+
+            # Single pane → resize should error (no split tree or trivial root)
+            surfaces_1 = c.list_surfaces()
+            if not surfaces_1:
+                raise cmuxError("no surfaces in fresh workspace")
+            solo_id = surfaces_1[0][1]
+
+            _expect_error(
+                "resize single pane",
+                lambda: c._call(
+                    "pane.resize",
+                    {"workspace_id": ws, "pane_id": solo_id, "direction": "right"},
+                ),
+            )
+
+            # Split right → creates [s0 | s1] horizontal split
+            s1 = c.new_split("right")
+            time.sleep(0.1)
+            if not s1:
+                raise cmuxError("surface.split returned no id")
+
+            surfaces_2 = c.list_surfaces()
+            if len(surfaces_2) < 2:
+                raise cmuxError(f"expected >= 2 surfaces after split, got {len(surfaces_2)}")
+            s0_id = surfaces_2[0][1]
+            s1_id = surfaces_2[1][1]
+
+            # Resize right from s0 (first child) → ratio increases from 0.5
+            res1 = c._call(
+                "pane.resize",
+                {"workspace_id": ws, "pane_id": s0_id, "direction": "right"},
+            )
+            if not isinstance(res1, dict):
+                raise cmuxError(f"resize right returned {res1!r}")
+            r1 = res1.get("ratio")
+            if r1 is None or r1 <= 0.5:
+                raise cmuxError(f"resize right should increase ratio above 0.5, got {r1}")
+
+            # Resize left from s1 (second child) → ratio decreases
+            res2 = c._call(
+                "pane.resize",
+                {"workspace_id": ws, "pane_id": s1_id, "direction": "left"},
+            )
+            r2 = res2.get("ratio")
+            if r2 is None or r2 >= r1:
+                raise cmuxError(f"resize left should decrease ratio below {r1}, got {r2}")
+
+            # Multiple amount: resize right by 5 from s0 → big jump
+            res3 = c._call(
+                "pane.resize",
+                {
+                    "workspace_id": ws,
+                    "pane_id": s0_id,
+                    "direction": "right",
+                    "amount": 5,
+                },
+            )
+            r3 = res3.get("ratio")
+            if r3 is None or r3 <= r2:
+                raise cmuxError(f"resize right amount=5 should increase, got {r3}")
+
+            # Clamp at 0.9: keep pushing right
+            for _ in range(20):
+                c._call(
+                    "pane.resize",
+                    {"workspace_id": ws, "pane_id": s0_id, "direction": "right", "amount": 5},
+                )
+            res_max = c._call(
+                "pane.resize",
+                {"workspace_id": ws, "pane_id": s0_id, "direction": "right"},
+            )
+            r_max = res_max.get("ratio", 0)
+            if r_max > 0.9 + 0.001:
+                raise cmuxError(f"ratio should clamp at 0.9, got {r_max}")
+
+            # Clamp at 0.1: push left from s1 many times
+            for _ in range(20):
+                c._call(
+                    "pane.resize",
+                    {"workspace_id": ws, "pane_id": s1_id, "direction": "left", "amount": 5},
+                )
+            res_min = c._call(
+                "pane.resize",
+                {"workspace_id": ws, "pane_id": s1_id, "direction": "left"},
+            )
+            r_min = res_min.get("ratio", 1)
+            if r_min < 0.1 - 0.001:
+                raise cmuxError(f"ratio should clamp at 0.1, got {r_min}")
+
+            # Bad direction → error
+            _expect_error(
+                "bad direction",
+                lambda: c._call(
+                    "pane.resize",
+                    {"workspace_id": ws, "pane_id": s0_id, "direction": "diagonal"},
+                ),
+            )
+
+            # Resize up/down on a horizontal-only split → no matching ancestor
+            _expect_error(
+                "no vertical split",
+                lambda: c._call(
+                    "pane.resize",
+                    {"workspace_id": ws, "pane_id": s0_id, "direction": "up"},
+                ),
+            )
+
+        finally:
+            if ws is not None:
+                try:
+                    c.close_workspace(ws)
+                except Exception:
+                    pass
+
+    print("PASS: pane.resize (ratio adjust, clamp, errors)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except cmuxError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

Implements the v2 \`pane.resize\` RPC on Linux by walking the split tree
to find the innermost ancestor split node matching the requested direction
and adjusting its divider ratio.

## How it works

- \`direction\`: left/right → horizontal splits, up/down → vertical splits
- \`amount\` (default 1): each unit adjusts ratio by 0.05 (5%)
- Ratio clamped to [0.1, 0.9]
- In real GTK mode, updates the GtkPaned widget position immediately
- Returns \`{pane_id, direction, ratio}\` with the new ratio

## What's added

- \`cmux-linux/src/split_tree.zig\`:
  - \`containsPanel\`: check if a subtree contains a given panel
  - \`findResizeSplit\`: find innermost matching split ancestor for a pane,
    given orientation and first/second-child position
- \`cmux-linux/src/socket.zig\`: \`handlePaneResize\` handler (~65 LOC)
- \`tests_v2/test_pane_resize.py\` covering:
  - ratio increase (right) and decrease (left)
  - multi-step amount
  - clamping at 0.1/0.9 bounds
  - single-pane error (no split tree)
  - bad direction error
  - no-matching-split-ancestor error (e.g. up/down on horizontal-only split)

## Linux vs macOS

macOS computes delta from pixel dimensions
(\`amount / axisPixels\`). Linux uses a fixed \`0.05\` step per unit since
CMUX_NO_SURFACE mode has no real pixel allocations. In real GTK mode
the ratio is applied to the GtkPaned's actual allocation.

## Test plan

- [ ] Socket tests CI is green
- [ ] Distro tests CI is green

Refs #220 (Sprint A item #3).