### PR TITLE
linux(socket): implement surface.action new_terminal_right/new_browser_right/reload/duplicate

### DIFF
--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -1774,8 +1774,8 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
         const idx = anchor_idx orelse return "{\"error\":\"surface not in panel order\"}";
 
         // Collect IDs to remove (snapshot before mutation).
-        var to_close = std.ArrayList(u128).init(alloc);
-        defer to_close.deinit();
+        var to_close = std.ArrayList(u128).empty;
+        defer to_close.deinit(alloc);
         var skipped_pinned: usize = 0;
 
         for (ws.ordered_panels.items, 0..) |id, i| {
@@ -1796,7 +1796,7 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
                     continue;
                 }
             }
-            to_close.append(id) catch continue;
+            to_close.append(alloc, id) catch continue;
         }
 
         // Remove collected panels (split tree + panel map).

--- a/cmux-linux/src/socket.zig
+++ b/cmux-linux/src/socket.zig
@@ -1655,11 +1655,10 @@ fn handleSurfaceClearHistory(_: Allocator, _: json.Value) []const u8 {
 /// surface.action / tab.action — apply a tab-level action to a surface.
 ///
 /// Mirrors macOS `v2TabAction` (Sources/TerminalController.swift). Linux
-/// implements property-mutation actions (rename, clear_name, pin, unpin,
-/// mark_read, mark_unread) and relative-close actions (close_left,
-/// close_right, close_others). Remaining actions (new_terminal_right,
-/// new_browser_right, reload, duplicate) are not yet wired and return
-/// an `unsupported` error so callers can detect parity gaps.
+/// implements: property-mutation (rename, clear_name, pin, unpin, mark_read,
+/// mark_unread), relative-close (close_left, close_right, close_others),
+/// panel-creation (new_terminal_right, new_browser_right, duplicate), and
+/// browser-specific (reload).
 fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
     const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";
 
@@ -1826,22 +1825,179 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
         ) catch "{}";
     }
 
-    // Recognized but not yet implemented on Linux. Returning a structured
-    // error lets callers distinguish "wrong call" from "platform gap".
-    // `action` is user input — escape it via writeJsonString.
-    if (std.mem.eql(u8, action, "new_terminal_right") or
-        std.mem.eql(u8, action, "new_browser_right") or
-        std.mem.eql(u8, action, "reload") or
-        std.mem.eql(u8, action, "duplicate"))
-    {
-        var buf: std.ArrayList(u8) = .empty;
-        const w = buf.writer(alloc);
-        w.writeAll("{\"error\":\"action not implemented on linux\",\"action\":") catch
-            return "{\"error\":\"action not implemented on linux\"}";
-        writeJsonString(w, action) catch
-            return "{\"error\":\"action not implemented on linux\"}";
-        w.writeByte('}') catch return "{\"error\":\"action not implemented on linux\"}";
-        return buf.toOwnedSlice(alloc) catch "{\"error\":\"action not implemented on linux\"}";
+    // ── new_terminal_right ───────────────────────────────────────────
+    // Create a new terminal panel and insert it immediately after the
+    // target in ordered_panels.  On Linux 1:1 panel model this adds a
+    // new sidebar entry; on macOS it opens a tab to the right.
+    if (std.mem.eql(u8, action, "new_terminal_right")) {
+        const new_panel = if (isNoSurface())
+            ws.createMockPanel(.terminal) catch return "{\"error\":\"create panel failed\"}"
+        else
+            ws.createTerminalPanel(tm.ghostty_app) catch return "{\"error\":\"create panel failed\"}";
+
+        // createMockPanel / createTerminalPanel appends to end — reposition
+        // to target_pos + 1 so the new panel is "to the right" of the anchor.
+        const last_idx = ws.ordered_panels.items.len - 1;
+        _ = ws.ordered_panels.orderedRemove(last_idx);
+        var target_pos: usize = ws.ordered_panels.items.len; // fallback: end
+        for (ws.ordered_panels.items, 0..) |id, i| {
+            if (id == target_id) {
+                target_pos = i + 1;
+                break;
+            }
+        }
+        const insert_pos = @min(target_pos, ws.ordered_panels.items.len);
+        ws.ordered_panels.insert(ws.alloc, insert_pos, new_panel.id) catch {
+            ws.ordered_panels.append(ws.alloc, new_panel.id) catch {};
+        };
+
+        // Add to split tree
+        if (ws.root_node) |root| {
+            if (split_tree.findLeaf(root, target_id)) |_| {
+                ws.root_node = split_tree.splitPane(
+                    ws.alloc, root, .horizontal, new_panel.id, new_panel.widget,
+                ) catch null;
+            }
+        }
+
+        // Rebuild widget tree in real GTK mode
+        if (!isNoSurface()) {
+            if (ws.root_node) |new_root| {
+                ws.content_widget = split_tree.buildWidget(new_root);
+            }
+        }
+        if (window.getSidebar()) |sb| sb.refresh();
+        ws.focused_panel_id = new_panel.id;
+
+        const new_hex = formatId(new_panel.id);
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"new_terminal_right\",\"surface_id\":\"{s}\",\"new_surface_id\":\"{s}\"}}",
+            .{ panel_id_slice, @as([]const u8, &new_hex) },
+        ) catch "{}";
+    }
+
+    // ── new_browser_right ─────────────────────────────────────────────
+    // Same as new_terminal_right but creates a browser panel.  Requires
+    // WebKitGTK; returns error on no-webkit builds.
+    if (std.mem.eql(u8, action, "new_browser_right")) {
+        if (!c.has_webkit)
+            return "{\"error\":\"browser panels require WebKitGTK (-Dno-webkit was set)\"}";
+
+        const url = getParamString(params, "url");
+        const new_panel = if (isNoSurface())
+            ws.createMockPanel(.browser) catch return "{\"error\":\"create panel failed\"}"
+        else
+            ws.createBrowserPanel(url) catch return "{\"error\":\"create browser panel failed\"}";
+
+        // Reposition: move from end to target_pos + 1
+        const last_idx = ws.ordered_panels.items.len - 1;
+        _ = ws.ordered_panels.orderedRemove(last_idx);
+        var target_pos: usize = ws.ordered_panels.items.len;
+        for (ws.ordered_panels.items, 0..) |id, i| {
+            if (id == target_id) {
+                target_pos = i + 1;
+                break;
+            }
+        }
+        const insert_pos = @min(target_pos, ws.ordered_panels.items.len);
+        ws.ordered_panels.insert(ws.alloc, insert_pos, new_panel.id) catch {
+            ws.ordered_panels.append(ws.alloc, new_panel.id) catch {};
+        };
+
+        if (ws.root_node) |root| {
+            if (split_tree.findLeaf(root, target_id)) |_| {
+                ws.root_node = split_tree.splitPane(
+                    ws.alloc, root, .horizontal, new_panel.id, new_panel.widget,
+                ) catch null;
+            }
+        }
+        if (!isNoSurface()) {
+            if (ws.root_node) |new_root| {
+                ws.content_widget = split_tree.buildWidget(new_root);
+            }
+        }
+        if (window.getSidebar()) |sb| sb.refresh();
+        ws.focused_panel_id = new_panel.id;
+
+        const new_hex = formatId(new_panel.id);
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"new_browser_right\",\"surface_id\":\"{s}\",\"new_surface_id\":\"{s}\"}}",
+            .{ panel_id_slice, @as([]const u8, &new_hex) },
+        ) catch "{}";
+    }
+
+    // ── reload ────────────────────────────────────────────────────────
+    // Browser panels: trigger WebKit reload.  Terminal panels: no-op
+    // error (matching macOS which only reloads browser tabs).
+    // Uses the comptime-gated `reloadBrowserWidget` helper so this
+    // always-analysed function doesn't force resolution of webkit symbols.
+    if (std.mem.eql(u8, action, "reload")) {
+        if (panel.panel_type != .browser)
+            return "{\"error\":\"reload is only supported for browser panels\"}";
+        if (!c.has_webkit)
+            return "{\"error\":\"browser panels require WebKitGTK (-Dno-webkit was set)\"}";
+        reloadBrowserWidget(panel.widget);
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"reload\",\"surface_id\":\"{s}\"}}",
+            .{panel_id_slice},
+        ) catch "{}";
+    }
+
+    // ── duplicate ─────────────────────────────────────────────────────
+    // Browser panels: create a new browser panel with the same URL,
+    // inserted to the right.  Terminal panels: not yet supported (would
+    // require CWD detection to spawn at the same directory).
+    if (std.mem.eql(u8, action, "duplicate")) {
+        if (panel.panel_type != .browser)
+            return "{\"error\":\"duplicate is only supported for browser panels\"}";
+        if (!c.has_webkit)
+            return "{\"error\":\"browser panels require WebKitGTK (-Dno-webkit was set)\"}";
+
+        const dup_url = panel.url;
+        const new_panel = if (isNoSurface())
+            ws.createMockPanel(.browser) catch return "{\"error\":\"create panel failed\"}"
+        else
+            ws.createBrowserPanel(dup_url) catch return "{\"error\":\"create browser panel failed\"}";
+
+        // Reposition to target_pos + 1
+        const last_idx = ws.ordered_panels.items.len - 1;
+        _ = ws.ordered_panels.orderedRemove(last_idx);
+        var target_pos: usize = ws.ordered_panels.items.len;
+        for (ws.ordered_panels.items, 0..) |id, i| {
+            if (id == target_id) {
+                target_pos = i + 1;
+                break;
+            }
+        }
+        const insert_pos = @min(target_pos, ws.ordered_panels.items.len);
+        ws.ordered_panels.insert(ws.alloc, insert_pos, new_panel.id) catch {
+            ws.ordered_panels.append(ws.alloc, new_panel.id) catch {};
+        };
+
+        if (ws.root_node) |root| {
+            if (split_tree.findLeaf(root, target_id)) |_| {
+                ws.root_node = split_tree.splitPane(
+                    ws.alloc, root, .horizontal, new_panel.id, new_panel.widget,
+                ) catch null;
+            }
+        }
+        if (!isNoSurface()) {
+            if (ws.root_node) |new_root| {
+                ws.content_widget = split_tree.buildWidget(new_root);
+            }
+        }
+        if (window.getSidebar()) |sb| sb.refresh();
+        ws.focused_panel_id = new_panel.id;
+
+        const new_hex = formatId(new_panel.id);
+        return std.fmt.allocPrint(
+            alloc,
+            "{{\"action\":\"duplicate\",\"surface_id\":\"{s}\",\"new_surface_id\":\"{s}\"}}",
+            .{ panel_id_slice, @as([]const u8, &new_hex) },
+        ) catch "{}";
     }
 
     // Unsupported action — same escape treatment for `action` echo.
@@ -1850,7 +2006,7 @@ fn handleSurfaceAction(alloc: Allocator, params: json.Value) []const u8 {
     w.writeAll("{\"error\":\"unsupported action\",\"action\":") catch
         return "{\"error\":\"unsupported action\"}";
     writeJsonString(w, action) catch return "{\"error\":\"unsupported action\"}";
-    w.writeAll(",\"supported\":[\"rename\",\"clear_name\",\"pin\",\"unpin\",\"mark_read\",\"mark_unread\",\"close_left\",\"close_right\",\"close_others\"]}") catch
+    w.writeAll(",\"supported\":[\"rename\",\"clear_name\",\"pin\",\"unpin\",\"mark_read\",\"mark_unread\",\"close_left\",\"close_right\",\"close_others\",\"new_terminal_right\",\"new_browser_right\",\"reload\",\"duplicate\"]}") catch
         return "{\"error\":\"unsupported action\"}";
     return buf.toOwnedSlice(alloc) catch "{\"error\":\"unsupported action\"}";
 }
@@ -2073,6 +2229,17 @@ fn handleBrowserUnavailable(_: Allocator, _: json.Value) []const u8 {
 }
 
 const browser_mod = @import("browser.zig");
+
+/// Reload a browser widget's WebView.  Compiled to a no-op when built
+/// without WebKitGTK so that callers inside always-analysed functions
+/// (like handleSurfaceAction) don't force resolution of webkit symbols.
+const reloadBrowserWidget = if (c.has_webkit) reloadBrowserWidgetImpl else reloadBrowserWidgetNoop;
+fn reloadBrowserWidgetImpl(panel_widget: ?*c.GtkWidget) void {
+    if (panel_widget) |widget| {
+        if (browser_mod.fromWidget(widget)) |bv| bv.reload();
+    }
+}
+fn reloadBrowserWidgetNoop(_: ?*c.GtkWidget) void {}
 
 fn handleBrowserOpenSplit(alloc: Allocator, params: json.Value) []const u8 {
     const tm = getTabManager() orelse return "{\"error\":\"no tab manager\"}";

--- a/tests_v2/test_surface_action_new_reload_duplicate.py
+++ b/tests_v2/test_surface_action_new_reload_duplicate.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Socket API: surface.action new_terminal_right / new_browser_right / reload / duplicate.
+
+Pure socket round-trip test -- no GUI, no CLI binary, no platform-specific
+filesystem assumptions. Designed to pass on both macOS and Linux daemons.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _surfaces_in(c: cmux, workspace_id: str) -> list[dict]:
+    """Return raw surface.list rows (dicts) for the given workspace."""
+    res = c._call("surface.list", {"workspace_id": workspace_id}) or {}
+    return list(res.get("surfaces") or [])
+
+
+def _surface_ids(c: cmux, workspace_id: str) -> list[str]:
+    """Return ordered list of surface IDs in the workspace."""
+    return [str(s.get("id")) for s in _surfaces_in(c, workspace_id)]
+
+
+def _run_assertions(c: cmux, ws_id: str) -> None:
+    """Run the full new_terminal_right / new_browser_right / reload / duplicate suite."""
+    c.select_workspace(ws_id)
+    time.sleep(0.05)
+
+    # Locate the focused surface in the workspace.
+    rows = _surfaces_in(c, ws_id)
+    if not rows:
+        raise cmuxError(f"new workspace has no surfaces: {rows}")
+    focused = next((r for r in rows if r.get("focused")), rows[0])
+    surface_id = str(focused["id"])
+    initial_count = len(rows)
+
+    # ---- new_terminal_right -------------------------------------------------
+    result = c._call(
+        "surface.action",
+        {
+            "workspace_id": ws_id,
+            "surface_id": surface_id,
+            "action": "new_terminal_right",
+        },
+    ) or {}
+
+    if result.get("action") != "new_terminal_right":
+        raise cmuxError(f"new_terminal_right: unexpected response: {result}")
+    new_id = result.get("new_surface_id")
+    if not new_id:
+        raise cmuxError(f"new_terminal_right: no new_surface_id: {result}")
+
+    # Surface count should increase by 1.
+    time.sleep(0.05)
+    ids_after = _surface_ids(c, ws_id)
+    if len(ids_after) != initial_count + 1:
+        raise cmuxError(
+            f"new_terminal_right: expected {initial_count + 1} surfaces, "
+            f"got {len(ids_after)}"
+        )
+    if new_id not in ids_after:
+        raise cmuxError(f"new_terminal_right: new surface {new_id} not in list")
+
+    # New surface should appear after the anchor in ordered position.
+    anchor_pos = ids_after.index(surface_id)
+    new_pos = ids_after.index(new_id)
+    if new_pos != anchor_pos + 1:
+        raise cmuxError(
+            f"new_terminal_right: expected new at pos {anchor_pos + 1}, "
+            f"got {new_pos}"
+        )
+
+    # ---- new_terminal_right via tab.action alias ----------------------------
+    alias_result = c._call(
+        "tab.action",
+        {
+            "workspace_id": ws_id,
+            "tab_id": surface_id,
+            "action": "new_terminal_right",
+        },
+    ) or {}
+    if alias_result.get("action") != "new_terminal_right":
+        raise cmuxError(f"tab.action alias: unexpected response: {alias_result}")
+    alias_new_id = alias_result.get("new_surface_id")
+    if not alias_new_id:
+        raise cmuxError(f"tab.action alias: no new_surface_id: {alias_result}")
+
+    # ---- reload on terminal panel returns error ----------------------------
+    reload_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": ws_id,
+            "surface_id": surface_id,
+            "action": "reload",
+        },
+    ) or {}
+    # Terminal panels should return an error (reload is browser-only).
+    if "error" not in reload_resp:
+        raise cmuxError(f"reload on terminal: expected error, got {reload_resp}")
+
+    # ---- duplicate on terminal panel returns error -------------------------
+    dup_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": ws_id,
+            "surface_id": surface_id,
+            "action": "duplicate",
+        },
+    ) or {}
+    if "error" not in dup_resp:
+        raise cmuxError(f"duplicate on terminal: expected error, got {dup_resp}")
+
+    # ---- new_browser_right -------------------------------------------------
+    # May succeed (webkit available) or return error (no webkit).  Either
+    # is acceptable -- the test validates the response shape, not webkit.
+    browser_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": ws_id,
+            "surface_id": surface_id,
+            "action": "new_browser_right",
+        },
+    ) or {}
+    if "error" in browser_resp:
+        # Acceptable: no-webkit build or browser panel unavailable.
+        pass
+    elif browser_resp.get("action") != "new_browser_right":
+        raise cmuxError(f"new_browser_right: unexpected response: {browser_resp}")
+    elif not browser_resp.get("new_surface_id"):
+        raise cmuxError(f"new_browser_right: no new_surface_id: {browser_resp}")
+
+    # ---- focused-surface fallback (no surface_id) --------------------------
+    fallback_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": ws_id,
+            "action": "new_terminal_right",
+        },
+    ) or {}
+    if fallback_resp.get("action") != "new_terminal_right":
+        raise cmuxError(
+            f"focused-surface fallback: unexpected response: {fallback_resp}"
+        )
+    if not fallback_resp.get("new_surface_id"):
+        raise cmuxError(
+            f"focused-surface fallback: no new_surface_id: {fallback_resp}"
+        )
+
+    # ---- unsupported action still returns structured error ------------------
+    bad_resp = c._call(
+        "surface.action",
+        {
+            "workspace_id": ws_id,
+            "surface_id": surface_id,
+            "action": "definitely-not-a-real-action",
+        },
+    ) or {}
+    # Response should contain an "error" key and "supported" list.
+    if "supported" in bad_resp:
+        supported = bad_resp["supported"]
+        for expected in (
+            "new_terminal_right",
+            "new_browser_right",
+            "reload",
+            "duplicate",
+        ):
+            if expected not in supported:
+                raise cmuxError(
+                    f"supported list missing {expected!r}: {supported}"
+                )
+
+
+def main() -> int:
+    created_workspace: str | None = None
+    with cmux(SOCKET_PATH) as c:
+        try:
+            created_workspace = c.new_workspace()
+            if not created_workspace:
+                raise cmuxError("workspace.create returned no id")
+            _run_assertions(c, created_workspace)
+        finally:
+            if created_workspace is not None:
+                try:
+                    c.close_workspace(created_workspace)
+                except Exception:
+                    pass
+
+    print(
+        "PASS: surface.action new_terminal_right / new_browser_right / "
+        "reload / duplicate"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except cmuxError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Implement the last four `surface.action` variants: `new_terminal_right`, `new_browser_right`, `reload`, `duplicate`
- `new_terminal_right` creates a terminal panel and inserts at target+1 in ordered_panels with split tree integration
- `new_browser_right` creates a browser panel (requires WebKitGTK; returns structured error on no-webkit builds)
- `reload` triggers WebKit reload for browser panels; returns error for terminal panels
- `duplicate` creates a new browser panel with the same URL; returns error for terminal panels
- Uses comptime-gated `reloadBrowserWidget` helper to avoid webkit symbol resolution in RHEL/Rocky no-webkit builds
- Completes Sprint A items 9-10 from #220

## Test plan
- [ ] Linux CI (Debian, Ubuntu, Fedora, Arch, Rocky) compiles including no-webkit variant
- [ ] `tests_v2/test_surface_action_new_reload_duplicate.py` passes on honey runner
- [ ] `new_terminal_right` creates panel at correct ordered position
- [ ] `reload`/`duplicate` return structured errors for terminal panels
- [ ] `new_browser_right` returns structured error on no-webkit builds
- [ ] Existing surface.action tests still pass (rename, pin, close variants)