### PR TITLE
feat(nix): downloadable QCOW2 demo VM images

### DIFF
--- a/.github/workflows/release-qcow2.yml
+++ b/.github/workflows/release-qcow2.yml
@@ -1,0 +1,120 @@
+name: QCOW2 Demo VM Images
+
+on:
+  push:
+    tags:
+      - 'lab-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. lab-v0.73.0)'
+        required: true
+
+concurrency:
+  group: release-qcow2
+  cancel-in-progress: false
+
+jobs:
+  build-qcow2:
+    name: Build QCOW2 (${{ matrix.variant }})
+    runs-on: [self-hosted, linux, kvm, cmux-distro-test]
+    environment: distro-tests
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      # Build sequentially via max-parallel to avoid disk pressure on honey.
+      max-parallel: 1
+      matrix:
+        variant: [gnome, sway, hyprland]
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Strip non-version tags from ghostty
+        run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="${TAG#lab-v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building QCOW2 ${{ matrix.variant }} for $TAG (version $VERSION)"
+
+      - name: Build QCOW2 image
+        run: |
+          nix build .#qcow2-${{ matrix.variant }} \
+            --print-build-logs -L \
+            --option sandbox relaxed
+
+      - name: Compress QCOW2 image
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          RAW=$(find result/ -name '*.qcow2' -o -name 'nixos.qcow2' | head -1)
+          if [ -z "$RAW" ]; then
+            # nixos-generators may place the image directly at result
+            RAW="result"
+          fi
+          OUT="cmux-demo-${VARIANT}-${VERSION}.qcow2"
+          qemu-img convert -c -O qcow2 "$RAW" "$OUT"
+          echo "Compressed: $OUT ($(du -h "$OUT" | cut -f1))"
+          qemu-img info "$OUT"
+
+      - name: Upload QCOW2 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmux-qcow2-${{ matrix.variant }}
+          path: cmux-demo-*.qcow2
+          if-no-files-found: error
+
+  release:
+    name: Upload QCOW2 images to release
+    needs: [build-qcow2]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all QCOW2 artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Upload to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.build-qcow2.outputs.tag }}
+        run: |
+          ASSETS=()
+          for f in cmux-qcow2-*/*.qcow2; do
+            [ -f "$f" ] && ASSETS+=("$f")
+          done
+
+          echo "Uploading ${#ASSETS[@]} QCOW2 images for $TAG:"
+          printf '  %s\n' "${ASSETS[@]}"
+
+          if [ ${#ASSETS[@]} -eq 0 ]; then
+            echo "ERROR: No QCOW2 artifacts found"
+            ls -laR cmux-qcow2-*/ || true
+            exit 1
+          fi
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG exists, uploading QCOW2 images..."
+            gh release upload "$TAG" "${ASSETS[@]}" --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            echo "Creating release $TAG with QCOW2 images..."
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "cmux $TAG" \
+              --notes "QCOW2 demo VM images for $TAG" \
+              "${ASSETS[@]}"
+          fi

--- a/flake.lock
+++ b/flake.lock
@@ -70,6 +70,42 @@
         "type": "github"
       }
     },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1736643958,
+        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixos-generators": {
+      "inputs": {
+        "nixlib": "nixlib",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769813415,
+        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774610258,
@@ -88,6 +124,7 @@
         "flake-utils": "flake-utils",
         "ghostty-src": "ghostty-src",
         "nix-vm-test": "nix-vm-test",
+        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs",
         "zig": "zig"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,12 @@
       url = "github:Jesssullivan/ghostty";
       flake = false;
     };
+
+    # QCOW2 / cloud image builder
+    nixos-generators = {
+      url = "github:nix-community/nixos-generators";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
@@ -33,6 +39,7 @@
     zig,
     nix-vm-test,
     ghostty-src,
+    nixos-generators,
     ...
   }: let
     inherit (nixpkgs) lib legacyPackages;
@@ -137,6 +144,25 @@
         cmux-linux = pkgs.callPackage ./nix/cmux-linux.nix {
           zig_0_15 = zig.packages.${pkgs.stdenv.hostPlatform.system}."0.15.2";
           libghostty = self.packages.${pkgs.stdenv.hostPlatform.system}.libghostty;
+        };
+
+      }
+      // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
+        # Downloadable QCOW2 demo VM images (x86_64-linux only)
+        qcow2-gnome = import ./nix/vm/image-builder.nix {
+          inherit nixpkgs nixos-generators;
+          module = ./nix/vm/wayland-gnome.nix;
+          overlay = self.overlays.default;
+        };
+        qcow2-sway = import ./nix/vm/image-builder.nix {
+          inherit nixpkgs nixos-generators;
+          module = ./nix/vm/wayland-sway.nix;
+          overlay = self.overlays.default;
+        };
+        qcow2-hyprland = import ./nix/vm/image-builder.nix {
+          inherit nixpkgs nixos-generators;
+          module = ./nix/vm/wayland-hyprland.nix;
+          overlay = self.overlays.default;
         };
       });
 

--- a/nix/vm/image-builder.nix
+++ b/nix/vm/image-builder.nix
@@ -1,0 +1,41 @@
+# QCOW2 disk image builder — produces downloadable demo images.
+#
+# Reuses the same desktop modules as interactive VMs (wayland-gnome.nix,
+# wayland-sway.nix, wayland-hyprland.nix) but outputs a persistent QCOW2
+# disk image instead of an ephemeral QEMU runner.
+#
+# Usage from flake.nix:
+#   qcow2-gnome = import ./nix/vm/image-builder.nix {
+#     inherit nixpkgs nixos-generators;
+#     module = ./nix/vm/wayland-gnome.nix;
+#     overlay = self.overlays.default;
+#   };
+#
+# Build:
+#   nix build .#qcow2-gnome   (x86_64-linux only)
+{
+  nixpkgs,
+  nixos-generators,
+  module,
+  overlay ? (_: _: {}),
+}: let
+  # Pre-apply the overlay so cmux-linux is available in pkgs, then
+  # pass via specialArgs to avoid nixpkgs.overlays module recursion.
+  pkgs = import nixpkgs {
+    system = "x86_64-linux";
+    overlays = [overlay];
+  };
+in
+  nixos-generators.nixosGenerate {
+    system = "x86_64-linux";
+    format = "qcow";
+    specialArgs = {
+      cmuxPkg = pkgs.cmux-linux or null;
+    };
+    modules = [
+      # image-extras.nix MUST come before common.nix (imported via module)
+      # so it can override boot/virtualisation settings with lib.mkForce.
+      ./image-extras.nix
+      module
+    ];
+  }

--- a/nix/vm/image-extras.nix
+++ b/nix/vm/image-extras.nix
@@ -1,0 +1,48 @@
+# Image-specific overrides for QCOW2 demo images.
+#
+# nixos-generators "qcow" format uses GRUB (not systemd-boot) and sets its
+# own boot/filesystem config.  common.nix enables systemd-boot, which
+# conflicts — so we disable it here with mkForce.
+#
+# cmux-linux is passed via specialArgs from image-builder.nix to avoid
+# the infinite recursion that occurs with nixpkgs.overlays in modules.
+{
+  lib,
+  pkgs,
+  cmuxPkg ? null,
+  ...
+}: {
+  # ── Boot: let nixos-generators own the bootloader ──────────────
+  boot.loader.systemd-boot.enable = lib.mkForce false;
+  boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
+
+  # ── Disk ───────────────────────────────────────────────────────
+  # 10 GB raw, compresses to <2 GB with qemu-img convert -c.
+  virtualisation.diskSize = 10 * 1024; # MiB
+
+  # ── Identity ───────────────────────────────────────────────────
+  networking.hostName = "cmux-demo";
+
+  # ── Packages ───────────────────────────────────────────────────
+  environment.systemPackages =
+    lib.optionals (cmuxPkg != null) [cmuxPkg];
+
+  # ── XDG autostart for cmux ─────────────────────────────────────
+  # Drop a .desktop file so cmux launches on login in GNOME/Sway/Hyprland.
+  environment.etc."xdg/autostart/cmux.desktop".text = ''
+    [Desktop Entry]
+    Type=Application
+    Name=cmux
+    Exec=cmux
+    X-GNOME-Autostart-enabled=true
+  '';
+
+  # ── SPICE: not needed in downloadable images ───────────────────
+  # Users importing into GNOME Boxes / virt-manager get their own agent.
+  services.spice-vdagentd.enable = lib.mkForce false;
+
+  # ── Nix: keep the image self-contained ─────────────────────────
+  nix.settings.experimental-features = ["nix-command" "flakes"];
+
+  system.stateVersion = lib.trivial.release;
+}


### PR DESCRIPTION
## Summary

- Add `nixos-generators` flake input for building persistent QCOW2 disk images
- Create `nix/vm/image-builder.nix` + `nix/vm/image-extras.nix` — reuses existing desktop modules (GNOME/Sway/Hyprland) with boot/disk/autostart overrides
- Gate `qcow2-gnome`, `qcow2-sway`, `qcow2-hyprland` packages to x86_64-linux only
- Add `release-qcow2.yml` CI workflow: sequential builds on honey KVM runner, `qemu-img convert -c` compression, upload to GitHub Release

## Architecture

```
image-builder.nix
  ├── Pre-applies overlay to pkgs (avoids nixpkgs.overlays recursion)
  ├── Passes cmux-linux via specialArgs
  └── Calls nixos-generators.nixosGenerate { format = "qcow"; }
        └── image-extras.nix (boot/disk/hostname/autostart overrides)
        └── wayland-{gnome,sway,hyprland}.nix (existing desktop modules)
```

## Test plan

- [x] `nix eval .#packages.x86_64-linux.qcow2-gnome.name` → `"nixos-disk-image"`
- [x] `nix eval .#packages.x86_64-linux.qcow2-sway.name` → `"nixos-disk-image"`
- [x] `nix eval .#packages.x86_64-linux.qcow2-hyprland.name` → `"nixos-disk-image"`
- [x] `nix flake show --all-systems` — no infinite recursion, no errors on x86_64-linux
- [ ] `nix build .#qcow2-gnome` on honey (x86_64-linux KVM runner)
- [ ] Boot resulting QCOW2 in GNOME Boxes / virt-manager

Closes #220 Task #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)