### PR TITLE
docs: update ghostty-fork.md SHA + branch cleanup

### DIFF
--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -16,23 +16,17 @@ When we change the fork, update this document and the parent submodule SHA.
 Fork rebased onto upstream `main` at `3509ccf78` (`v1.3.1-457-g3509ccf78`) on March 30, 2026.
 Merged upstream through `0a492fdb3` (build: add pkg-config static linking support) on April 4, 2026.
 Synced again with upstream on April 11, 2026 (through `d289f66f`).
+Synced again with upstream on April 6, 2026 (PR #11, through `ca7516bea`).
 
-As of April 13, 2026:
+As of April 18, 2026:
 
-- Current cmux pinned fork head: `5dd2aa015`
-- Current pushed fork `main`: `5dd2aa015`
-- Current upstream `main`: `7421b4b13`
+- Current cmux pinned fork head: `e0f650766`
+- Current pushed fork `main`: `e0f650766`
+- Current upstream `main`: `ca7516bea`
 
-Important hygiene note:
-
-- the parent repo now points at a commit reachable from pushed fork `main`
-- the sanitized reconciliation branch `origin/sid-upstream-sync-apr13-clean`
-  was merged into fork `main`
-- the prior detached-only parent pin `5080f910e` has been superseded by the
-  canonical fork-main commit `5dd2aa015`
-
-This resolves the earlier branch-topology problem. Future parent-repo Ghostty
-bumps should continue to point only at commits reachable from `origin/main`.
+Branch cleanup (April 18, 2026): deleted 15 stale local branches and 16 stale
+remote branches from the fork. Only `main` remains. All feature/sync branches
+were already merged or superseded by upstream syncs.
 
 ### 1) macOS display link restart on display changes
 


### PR DESCRIPTION
## Summary

- Update ghostty fork pinned SHA: `5dd2aa015` → `e0f650766` (PR #11 upstream sync)
- Update upstream HEAD: `7421b4b13` → `ca7516bea`
- Document April 18 branch cleanup across all submodules

### Branch cleanup totals

| Repo | Local deleted | Remote deleted |
|------|--------------|----------------|
| cmux | 12 | 14 (pruned) |
| ghostty fork | 15 | 16 |
| bonsplit fork | 3 | 25 (17 merged + 8 superseded) |

## Test plan

- [x] Doc-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)