### PR TITLE
linux: implement runtime callbacks (close surface, set title, pwd)

### DIFF
--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -10,11 +10,75 @@ const window = @import("window.zig");
 /// Returns true if handled, false to let libghostty handle it.
 pub fn onAction(
     _: c.ghostty_app_t,
-    _: c.ghostty.ghostty_target_s,
-    _: c.ghostty.ghostty_action_s,
+    target: c.ghostty.ghostty_target_s,
+    action: c.ghostty.ghostty_action_s,
 ) callconv(.c) bool {
-    // TODO: dispatch actions (new_tab, close_tab, set_title, etc.)
+    return switch (action.tag) {
+        c.ghostty.GHOSTTY_ACTION_SET_TITLE => handleSetTitle(target, action.action.set_title),
+        c.ghostty.GHOSTTY_ACTION_PWD => handlePwd(target, action.action.pwd),
+        else => false,
+    };
+}
+
+/// Update the panel/workspace title from terminal escape sequences.
+fn handleSetTitle(target: c.ghostty.ghostty_target_s, title: c.ghostty.ghostty_action_set_title_s) bool {
+    const tm = window.getTabManager() orelse return false;
+    const title_str = if (title.title) |t| std.mem.span(t) else return false;
+
+    // Find the surface from target and update its workspace title.
+    const surface_ud = getSurfaceUserdata(target) orelse return false;
+    const widget: *c.GtkWidget = @ptrCast(@alignCast(surface_ud));
+
+    for (tm.workspaces.items) |ws| {
+        var it = ws.panels.valueIterator();
+        while (it.next()) |panel_ptr| {
+            const panel = panel_ptr.*;
+            if (panel.widget) |pw| {
+                if (pw == widget) {
+                    // Set panel title
+                    panel.title = ws.alloc.dupe(u8, title_str) catch null;
+                    // If no custom workspace title, propagate to workspace
+                    if (ws.custom_title == null) {
+                        ws.setTitle(title_str);
+                        tm.updateTabTitle(ws);
+                    }
+                    return true;
+                }
+            }
+        }
+    }
     return false;
+}
+
+/// Update the workspace's current directory from shell integration.
+fn handlePwd(target: c.ghostty.ghostty_target_s, pwd: c.ghostty.ghostty_action_pwd_s) bool {
+    const tm = window.getTabManager() orelse return false;
+    const pwd_str = if (pwd.pwd) |p| std.mem.span(p) else return false;
+
+    const surface_ud = getSurfaceUserdata(target) orelse return false;
+    const widget: *c.GtkWidget = @ptrCast(@alignCast(surface_ud));
+
+    for (tm.workspaces.items) |ws| {
+        var it = ws.panels.valueIterator();
+        while (it.next()) |panel_ptr| {
+            const panel = panel_ptr.*;
+            if (panel.widget) |pw| {
+                if (pw == widget) {
+                    panel.directory = ws.alloc.dupe(u8, pwd_str) catch null;
+                    ws.current_directory = ws.alloc.dupe(u8, pwd_str) catch null;
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+/// Extract the surface userdata pointer from a ghostty target.
+fn getSurfaceUserdata(target: c.ghostty.ghostty_target_s) ?*anyopaque {
+    if (target.tag != c.ghostty.GHOSTTY_TARGET_SURFACE) return null;
+    const surface = target.target.surface orelse return null;
+    return c.ghostty.ghostty_surface_userdata(surface);
 }
 
 /// Read clipboard callback: libghostty wants clipboard contents.

--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -45,7 +45,41 @@ pub fn onWriteClipboard(
 ) callconv(.c) void {}
 
 /// Close surface callback: terminal process exited or user requested close.
+/// The userdata is the GtkWidget pointer set during surface creation.
+/// Walk the tab manager to find the owning panel and remove it.
+/// If a workspace becomes empty after removal, close it.
 pub fn onCloseSurface(
-    _: ?*anyopaque,
+    userdata: ?*anyopaque,
     _: bool,
-) callconv(.c) void {}
+) callconv(.c) void {
+    const widget: *c.GtkWidget = @ptrCast(@alignCast(userdata orelse return));
+    const tm = window.getTabManager() orelse return;
+
+    // Find which workspace/panel owns this widget.
+    // Capture the panel ID first, then remove outside the iterator
+    // to avoid iterator invalidation.
+    var found_panel_id: ?u128 = null;
+    var found_ws_idx: usize = 0;
+    outer: for (tm.workspaces.items, 0..) |ws, ws_idx| {
+        var it = ws.panels.valueIterator();
+        while (it.next()) |panel_ptr| {
+            const panel = panel_ptr.*;
+            if (panel.widget) |pw| {
+                if (pw == widget) {
+                    found_panel_id = panel.id;
+                    found_ws_idx = ws_idx;
+                    break :outer;
+                }
+            }
+        }
+    }
+
+    const panel_id = found_panel_id orelse return;
+    const ws = tm.workspaces.items[found_ws_idx];
+    ws.removePanel(panel_id);
+
+    // If the workspace is now empty, close it (unless it's the last one).
+    if (ws.panelCount() == 0 and tm.workspaces.items.len > 1) {
+        tm.closeWorkspace(found_ws_idx);
+    }
+}

--- a/cmux-linux/src/surface.zig
+++ b/cmux-linux/src/surface.zig
@@ -97,6 +97,10 @@ pub const Surface = struct {
         } };
         surface_config.scale_factor = scale;
 
+        // Pass the GtkWidget pointer as surface userdata so the
+        // close_surface_cb can identify which panel to remove.
+        surface_config.userdata = @ptrCast(@alignCast(gl_area));
+
         surface.ghostty_surface = c.ghostty.ghostty_surface_new(
             surface.ghostty_app,
             &surface_config,


### PR DESCRIPTION
## Summary

- Set `surface_config.userdata` to the GtkWidget pointer during surface creation
- Implement `onCloseSurface` callback: walks tab manager to find the owning panel, removes it, closes empty workspaces
- Fixes dead shells remaining visible after terminal process exit

Previously `onCloseSurface` was a no-op stub (identified as a remaining gap from #207). Now libghostty's close notification properly triggers panel cleanup.

## Design notes

- **Iterator safety**: captures panel ID before calling `removePanel` to avoid hash map iterator invalidation
- **No double-free**: `panel.surface` is always null (ghostty surface lives on the `Surface` wrapper, not the panel struct), so `removePanel`'s `ghostty_surface_free` guard is a no-op — the surface is already freed by libghostty before calling the callback
- **Last-workspace guard**: won't close the final workspace, preserving a usable window state

## Test plan

- [x] Code review: no iterator invalidation, no double-free
- [ ] Launch cmux-linux, open terminal, run `exit` — panel should be removed
- [ ] With multiple workspaces: exit last shell in a workspace → workspace closes
- [ ] Single workspace with single shell: exit → workspace stays (empty but present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)