### PR TITLE
ci: move nix smoke jobs onto cmux-nix

### DIFF
--- a/.github/workflows/test-cjk.yml
+++ b/.github/workflows/test-cjk.yml
@@ -24,8 +24,8 @@ concurrency:
 
 jobs:
   cjk-input:
-    name: CJK input validation (honey)
-    runs-on: [self-hosted, linux, gpu, cmux-test]
+    name: CJK input validation (cmux-nix)
+    runs-on: cmux-nix
     environment: gpu-tests
     timeout-minutes: 30
     steps:
@@ -33,6 +33,19 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
+
+      - name: Setup GloriousFlywheel
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+
+      - name: Bootstrap Nix CLI
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+
+      - name: Verify runner Nix toolchain
+        run: nix --version
 
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -27,8 +27,8 @@ concurrency:
 
 jobs:
   gpu-smoke:
-    name: GPU smoke test (honey)
-    runs-on: [self-hosted, linux, gpu, cmux-test]
+    name: GPU smoke test (cmux-nix)
+    runs-on: cmux-nix
     # Require approval via GitHub Environment protection rules.
     environment: gpu-tests
     timeout-minutes: 30
@@ -37,6 +37,19 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
+
+      - name: Setup GloriousFlywheel
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+
+      - name: Bootstrap Nix CLI
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+
+      - name: Verify runner Nix toolchain
+        run: nix --version
 
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true

--- a/.github/workflows/test-socket.yml
+++ b/.github/workflows/test-socket.yml
@@ -27,8 +27,8 @@ concurrency:
 
 jobs:
   socket-tests:
-    name: Socket tests (honey)
-    runs-on: [self-hosted, linux, gpu, cmux-test]
+    name: Socket tests (cmux-nix)
+    runs-on: cmux-nix
     environment: gpu-tests
     timeout-minutes: 30
     steps:
@@ -36,6 +36,19 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
+
+      - name: Setup GloriousFlywheel
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+
+      - name: Bootstrap Nix CLI
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+
+      - name: Verify runner Nix toolchain
+        run: nix --version
 
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true


### PR DESCRIPTION
## Summary
- move the software-rendered self-hosted Linux smoke jobs from the dead `cmux-test` label to `cmux-nix`
- add the proven GloriousFlywheel Nix bootstrap contract used by `tummycrypt`
- leave the true hardware/KVM surface untouched in this PR

## Scope
This updates only:
- `test-socket.yml`
- `test-cjk.yml`
- `test-gpu.yml`

## Intentionally not fixed here
- `test-distro.yml` still requires a real KVM runner lane
- `test-ssh-proxy.yml` is still a separate design problem: the current Linux workflow self-skips because the needed CLI path is macOS-only
- the queued `cmux-test`/`cmux-distro-test` pet-runner labels are not removed by this PR; this PR only moves the ARC-eligible Nix jobs off them

## Validation
- `ruby` YAML parse for the edited workflows
- `git diff --check`
