### PR TITLE
linux: implement split pane actions, surface close, and input fixes

### DIFF
--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -470,8 +470,13 @@ fn handleResizeSplit(resize: c.ghostty.ghostty_action_resize_split_s) bool {
 
     const split = split_tree.findResizeSplit(root, focused_id, orientation, in_first) orelse return false;
 
-    // Adjust ratio by the amount (ghostty sends pixels, we convert to fraction)
-    const delta: f64 = @as(f64, @floatFromInt(resize.amount)) / 1000.0;
+    // Convert pixel amount to ratio fraction using the actual pane size.
+    const paned_size: c_int = switch (orientation) {
+        .horizontal => if (split.paned) |p| c.gtk.gtk_widget_get_width(p) else 0,
+        .vertical => if (split.paned) |p| c.gtk.gtk_widget_get_height(p) else 0,
+    };
+    if (paned_size <= 0) return false;
+    const delta: f64 = @as(f64, @floatFromInt(resize.amount)) / @as(f64, @floatFromInt(paned_size));
     const new_ratio = if (in_first) split.ratio + delta else split.ratio - delta;
     split.ratio = std.math.clamp(new_ratio, 0.1, 0.9);
 
@@ -515,28 +520,40 @@ fn findNodeByPanel(node: *split_tree.Node, panel_id: u128) ?*split_tree.Node {
 }
 
 /// Rebuild the workspace's GTK widget tree after a split tree mutation.
+/// Unparents leaf widgets before building the new tree so GTK4's
+/// parent assertion (gtk_widget_get_parent(child) == NULL) is satisfied.
 fn rebuildWorkspaceWidget(tm: *@import("tab_manager.zig").TabManager, ws: *@import("workspace.zig").Workspace) void {
     const root = ws.root_node orelse return;
     const old_widget = ws.content_widget;
 
-    // Build new widget tree
+    // Step 1: Remove the old page from AdwTabView so the root widget
+    // (and any directly-parented leaf) is unparented.
+    var insert_idx: c_int = 0;
+    if (tm.tab_view) |tv| {
+        if (old_widget) |ow| {
+            if (c.gtk.adw_tab_view_get_page(tv, ow)) |p| {
+                insert_idx = c.gtk.adw_tab_view_get_page_position(tv, p);
+                c.gtk.adw_tab_view_close_page(tv, p);
+            }
+        }
+    }
+
+    // Step 2: Detach leaf widgets from any old GtkPaned containers.
+    // Without this, nested leaves remain parented to the previous
+    // paned tree and buildWidget's set_start_child/set_end_child
+    // calls silently fail.
+    detachLeavesFromParents(root);
+
+    // Step 3: Build new widget tree (all leaves are now unparented).
     const new_widget = split_tree.buildWidget(root) orelse return;
     ws.content_widget = new_widget;
 
-    // Replace in AdwTabView
+    // Step 4: Insert the new widget tree into AdwTabView.
     if (tm.tab_view) |tv| {
-        if (old_widget) |ow| {
-            const page = c.gtk.adw_tab_view_get_page(tv, ow);
-            if (page) |p| {
-                // Remove old page and add new one at the same position
-                const idx = c.gtk.adw_tab_view_get_page_position(tv, p);
-                c.gtk.adw_tab_view_close_page(tv, p);
-                const new_page = c.gtk.adw_tab_view_insert(tv, new_widget, idx);
-                if (new_page) |np| {
-                    c.gtk.adw_tab_page_set_title(np, ws.displayTitle().ptr);
-                    c.gtk.adw_tab_view_set_selected_page(tv, np);
-                }
-            }
+        const new_page = c.gtk.adw_tab_view_insert(tv, new_widget, insert_idx);
+        if (new_page) |np| {
+            c.gtk.adw_tab_page_set_title(np, ws.displayTitle().ptr);
+            c.gtk.adw_tab_view_set_selected_page(tv, np);
         }
     }
 
@@ -548,6 +565,33 @@ fn rebuildWorkspaceWidget(tm: *@import("tab_manager.zig").TabManager, ws: *@impo
     const ctx = alloc.create(ApplyRatiosCtx) catch return;
     ctx.* = .{ .ws_id = ws.id };
     _ = c.gtk.g_idle_add(&applyRatiosIdle, ctx);
+}
+
+/// Detach leaf widgets from their current GTK parents.
+/// GTK4 requires widgets to be unparented before reparenting into a new
+/// container (gtk_paned_set_start_child asserts parent == NULL).
+fn detachLeavesFromParents(node: *split_tree.Node) void {
+    switch (node.*) {
+        .leaf => |leaf| {
+            if (leaf.widget) |w| {
+                const parent = c.gtk.gtk_widget_get_parent(w);
+                if (parent != null) {
+                    // GtkPaned children are removed via set_*_child(NULL)
+                    if (c.gtk.gtk_widget_get_first_child(parent) == w) {
+                        c.gtk.gtk_paned_set_start_child(@ptrCast(@alignCast(parent)), null);
+                    } else {
+                        c.gtk.gtk_paned_set_end_child(@ptrCast(@alignCast(parent)), null);
+                    }
+                }
+            }
+        },
+        .split => |*split| {
+            detachLeavesFromParents(split.first);
+            detachLeavesFromParents(split.second);
+            // Clear old paned reference — a new one will be created by buildWidget
+            split.paned = null;
+        },
+    }
 }
 
 /// Context for deferred ratio application.

--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const c = @import("c_api.zig");
 const window = @import("window.zig");
 const main_mod = @import("main.zig");
+const split_tree = @import("split_tree.zig");
 
 const log = std.log.scoped(.app);
 
@@ -40,6 +41,11 @@ pub fn onAction(
         c.ghostty.GHOSTTY_ACTION_COLOR_CHANGE => handleColorChange(action.action.color_change),
         c.ghostty.GHOSTTY_ACTION_RELOAD_CONFIG => handleReloadConfig(action.action.reload_config),
         c.ghostty.GHOSTTY_ACTION_CONFIG_CHANGE => handleConfigChange(action.action.config_change),
+        c.ghostty.GHOSTTY_ACTION_NEW_SPLIT => handleNewSplit(action.action.new_split),
+        c.ghostty.GHOSTTY_ACTION_GOTO_SPLIT => handleGotoSplit(action.action.goto_split),
+        c.ghostty.GHOSTTY_ACTION_RESIZE_SPLIT => handleResizeSplit(action.action.resize_split),
+        c.ghostty.GHOSTTY_ACTION_EQUALIZE_SPLITS => handleEqualizeSplits(),
+        c.ghostty.GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM => handleToggleSplitZoom(),
         else => false,
     };
 }
@@ -360,6 +366,189 @@ fn handleReloadConfig(reload: c.ghostty.ghostty_action_reload_config_s) bool {
 fn handleConfigChange(change: c.ghostty.ghostty_action_config_change_s) bool {
     _ = change; // Config key/value — will wire to settings UI later
     return true;
+}
+
+// ── Split management ───────────────────────────────────────────────
+
+/// Create a new split pane in the focused workspace.
+fn handleNewSplit(direction: c.ghostty.ghostty_action_split_direction_e) bool {
+    const tm = window.getTabManager() orelse return false;
+    const ws = tm.selectedWorkspace() orelse return false;
+    const root = ws.root_node orelse return false;
+    const focused_id = ws.focused_panel_id orelse return false;
+
+    // Determine orientation from ghostty direction
+    const orientation: split_tree.Orientation = switch (direction) {
+        c.ghostty.GHOSTTY_SPLIT_DIRECTION_RIGHT,
+        c.ghostty.GHOSTTY_SPLIT_DIRECTION_LEFT,
+        => .horizontal,
+        c.ghostty.GHOSTTY_SPLIT_DIRECTION_DOWN,
+        c.ghostty.GHOSTTY_SPLIT_DIRECTION_UP,
+        => .vertical,
+        else => .horizontal,
+    };
+
+    // Find the leaf node for the focused panel
+    const leaf = split_tree.findLeaf(root, focused_id) orelse return false;
+    _ = leaf;
+
+    // Create a new terminal panel
+    const panel = ws.createTerminalPanel(tm.ghostty_app) catch return false;
+
+    // Find and split the node containing the focused panel
+    const target = findNodeByPanel(root, focused_id) orelse return false;
+    _ = split_tree.splitPane(
+        ws.alloc,
+        target,
+        orientation,
+        panel.id,
+        panel.widget,
+    ) catch return false;
+
+    // Rebuild the GTK widget tree
+    rebuildWorkspaceWidget(tm, ws);
+    return true;
+}
+
+/// Navigate to an adjacent split pane.
+fn handleGotoSplit(goto: c.ghostty.ghostty_action_goto_split_e) bool {
+    const tm = window.getTabManager() orelse return false;
+    const ws = tm.selectedWorkspace() orelse return false;
+    const root = ws.root_node orelse return false;
+    const focused_id = ws.focused_panel_id orelse return false;
+
+    const direction: enum { next, previous } = switch (goto) {
+        c.ghostty.GHOSTTY_GOTO_SPLIT_NEXT,
+        c.ghostty.GHOSTTY_GOTO_SPLIT_RIGHT,
+        c.ghostty.GHOSTTY_GOTO_SPLIT_DOWN,
+        => .next,
+        c.ghostty.GHOSTTY_GOTO_SPLIT_PREVIOUS,
+        c.ghostty.GHOSTTY_GOTO_SPLIT_LEFT,
+        c.ghostty.GHOSTTY_GOTO_SPLIT_UP,
+        => .previous,
+        else => .next,
+    };
+
+    const target_leaf = split_tree.adjacentLeaf(root, focused_id, direction, ws.alloc) orelse return false;
+    ws.focused_panel_id = target_leaf.panel_id;
+
+    // Focus the target widget
+    if (target_leaf.widget) |w| {
+        _ = c.gtk.gtk_widget_grab_focus(w);
+    }
+    return true;
+}
+
+/// Resize the focused split pane.
+fn handleResizeSplit(resize: c.ghostty.ghostty_action_resize_split_s) bool {
+    const tm = window.getTabManager() orelse return false;
+    const ws = tm.selectedWorkspace() orelse return false;
+    const root = ws.root_node orelse return false;
+    const focused_id = ws.focused_panel_id orelse return false;
+
+    // Map ghostty resize direction to split_tree orientation and side
+    const orientation: split_tree.Orientation = switch (resize.direction) {
+        c.ghostty.GHOSTTY_RESIZE_SPLIT_LEFT,
+        c.ghostty.GHOSTTY_RESIZE_SPLIT_RIGHT,
+        => .horizontal,
+        c.ghostty.GHOSTTY_RESIZE_SPLIT_UP,
+        c.ghostty.GHOSTTY_RESIZE_SPLIT_DOWN,
+        => .vertical,
+        else => return false,
+    };
+
+    // Growing right/down means the panel is in the first child,
+    // growing left/up means it's in the second child.
+    const in_first = switch (resize.direction) {
+        c.ghostty.GHOSTTY_RESIZE_SPLIT_RIGHT,
+        c.ghostty.GHOSTTY_RESIZE_SPLIT_DOWN,
+        => true,
+        else => false,
+    };
+
+    const split = split_tree.findResizeSplit(root, focused_id, orientation, in_first) orelse return false;
+
+    // Adjust ratio by the amount (ghostty sends pixels, we convert to fraction)
+    const delta: f64 = @as(f64, @floatFromInt(resize.amount)) / 1000.0;
+    const new_ratio = if (in_first) split.ratio + delta else split.ratio - delta;
+    split.ratio = std.math.clamp(new_ratio, 0.1, 0.9);
+
+    // Apply the new ratio to the GtkPaned widget
+    split_tree.applyRatios(root);
+    return true;
+}
+
+/// Equalize all split ratios in the focused workspace.
+fn handleEqualizeSplits() bool {
+    const tm = window.getTabManager() orelse return false;
+    const ws = tm.selectedWorkspace() orelse return false;
+    const root = ws.root_node orelse return false;
+
+    split_tree.equalize(root);
+    split_tree.applyRatios(root);
+    return true;
+}
+
+/// Toggle split zoom (maximize focused pane / restore).
+/// Currently a no-op placeholder — needs show/hide logic for sibling panes.
+fn handleToggleSplitZoom() bool {
+    // TODO: implement zoom by hiding sibling panes and restoring them
+    log.info("toggle_split_zoom: not yet implemented", .{});
+    return true;
+}
+
+/// Find the Node (leaf or split) containing a panel by its ID.
+fn findNodeByPanel(node: *split_tree.Node, panel_id: u128) ?*split_tree.Node {
+    switch (node.*) {
+        .leaf => |leaf| {
+            if (leaf.panel_id == panel_id) return node;
+            return null;
+        },
+        .split => |split| {
+            if (findNodeByPanel(split.first, panel_id)) |n| return n;
+            if (findNodeByPanel(split.second, panel_id)) |n| return n;
+            return null;
+        },
+    }
+}
+
+/// Rebuild the workspace's GTK widget tree after a split tree mutation.
+fn rebuildWorkspaceWidget(tm: *@import("tab_manager.zig").TabManager, ws: *@import("workspace.zig").Workspace) void {
+    const root = ws.root_node orelse return;
+    const old_widget = ws.content_widget;
+
+    // Build new widget tree
+    const new_widget = split_tree.buildWidget(root) orelse return;
+    ws.content_widget = new_widget;
+
+    // Replace in AdwTabView
+    if (tm.tab_view) |tv| {
+        if (old_widget) |ow| {
+            const page = c.gtk.adw_tab_view_get_page(tv, ow);
+            if (page) |p| {
+                // Remove old page and add new one at the same position
+                const idx = c.gtk.adw_tab_view_get_page_position(tv, p);
+                c.gtk.adw_tab_view_close_page(tv, p);
+                const new_page = c.gtk.adw_tab_view_insert(tv, new_widget, idx);
+                if (new_page) |np| {
+                    c.gtk.adw_tab_page_set_title(np, ws.displayTitle().ptr);
+                    c.gtk.adw_tab_view_set_selected_page(tv, np);
+                }
+            }
+        }
+    }
+
+    // Apply split ratios after widget is allocated
+    // Use an idle callback so GTK has time to allocate sizes
+    _ = c.gtk.g_idle_add(&applyRatiosIdle, root);
+}
+
+/// GLib idle callback to apply split ratios after allocation.
+/// Returns G_SOURCE_REMOVE so it only fires once.
+fn applyRatiosIdle(data: ?*anyopaque) callconv(.c) c.gtk.gboolean {
+    const root: *split_tree.Node = @ptrCast(@alignCast(data orelse return c.gtk.G_SOURCE_REMOVE));
+    split_tree.applyRatios(root);
+    return c.gtk.G_SOURCE_REMOVE;
 }
 
 /// Extract the surface userdata pointer from a ghostty target.

--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -441,6 +441,10 @@ fn handleNewSplit(direction: c.ghostty.ghostty_action_split_direction_e) bool {
 
     // Rebuild the GTK widget tree
     rebuildWorkspaceWidget(tm, ws);
+
+    // Transfer GTK keyboard focus to the new pane so key events
+    // route to the same panel the data model considers focused.
+    if (panel.widget) |w| _ = c.gtk.gtk_widget_grab_focus(w);
     return true;
 }
 

--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -417,7 +417,7 @@ fn handleGotoSplit(goto: c.ghostty.ghostty_action_goto_split_e) bool {
     const root = ws.root_node orelse return false;
     const focused_id = ws.focused_panel_id orelse return false;
 
-    const direction: enum { next, previous } = switch (goto) {
+    const direction: split_tree.TraversalDirection = switch (goto) {
         c.ghostty.GHOSTTY_GOTO_SPLIT_NEXT,
         c.ghostty.GHOSTTY_GOTO_SPLIT_RIGHT,
         c.ghostty.GHOSTTY_GOTO_SPLIT_DOWN,

--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -46,6 +46,7 @@ pub fn onAction(
         c.ghostty.GHOSTTY_ACTION_RESIZE_SPLIT => handleResizeSplit(action.action.resize_split),
         c.ghostty.GHOSTTY_ACTION_EQUALIZE_SPLITS => handleEqualizeSplits(),
         c.ghostty.GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM => handleToggleSplitZoom(),
+        c.ghostty.GHOSTTY_ACTION_MOVE_TAB => handleMoveTab(action.action.move_tab),
         else => false,
     };
 }
@@ -150,6 +151,37 @@ fn handleCloseTab() bool {
     tm.closeWorkspace(idx);
     if (window.getSidebar()) |sb| sb.refresh();
     return true;
+}
+
+/// Reorder a tab by moving it left (negative) or right (positive).
+fn handleMoveTab(move: c.ghostty.ghostty_action_move_tab_s) bool {
+    const tm = window.getTabManager() orelse return false;
+    const count = tm.count();
+    if (count <= 1) return false;
+    const current = tm.selected_index orelse return false;
+
+    // Compute target index with wrapping
+    const amount: isize = @intCast(move.amount);
+    const current_i: isize = @intCast(current);
+    const count_i: isize = @intCast(count);
+    const raw_target = @mod(current_i + amount, count_i);
+    const target_idx: usize = @intCast(raw_target);
+
+    if (target_idx == current) return true;
+
+    // Use AdwTabView reorder API
+    if (tm.tab_view) |tv| {
+        const n_pages = c.gtk.adw_tab_view_get_n_pages(tv);
+        if (n_pages <= 1) return false;
+        const page = c.gtk.adw_tab_view_get_nth_page(tv, @intCast(current)) orelse return false;
+        const success = c.gtk.adw_tab_view_reorder_page(tv, page, @intCast(target_idx));
+        if (success != 0) {
+            tm.selected_index = target_idx;
+            if (window.getSidebar()) |sb| sb.refresh();
+        }
+        return success != 0;
+    }
+    return false;
 }
 
 /// Forward a desktop notification from the terminal (OSC 9/99).
@@ -762,6 +794,17 @@ pub fn onCloseSurface(
 
     const panel_id = found_panel_id orelse return;
     const ws = tm.workspaces.items[found_ws_idx];
+
+    // Update the split tree: close the pane and promote its sibling.
+    if (ws.root_node) |root| {
+        if (split_tree.leafCount(root) > 1) {
+            _ = split_tree.closePane(ws.alloc, root, panel_id);
+            ws.removePanel(panel_id);
+            rebuildWorkspaceWidget(tm, ws);
+            return;
+        }
+    }
+
     ws.removePanel(panel_id);
 
     // If the workspace is now empty, close it (unless it's the last one).

--- a/cmux-linux/src/app.zig
+++ b/cmux-linux/src/app.zig
@@ -388,22 +388,24 @@ fn handleNewSplit(direction: c.ghostty.ghostty_action_split_direction_e) bool {
         else => .horizontal,
     };
 
-    // Find the leaf node for the focused panel
-    const leaf = split_tree.findLeaf(root, focused_id) orelse return false;
-    _ = leaf;
+    // Find the target node BEFORE creating the panel to avoid orphans on failure
+    const target = findNodeByPanel(root, focused_id) orelse return false;
 
     // Create a new terminal panel
     const panel = ws.createTerminalPanel(tm.ghostty_app) catch return false;
 
-    // Find and split the node containing the focused panel
-    const target = findNodeByPanel(root, focused_id) orelse return false;
+    // Split the target node; clean up on failure to avoid orphaned panel
     _ = split_tree.splitPane(
         ws.alloc,
         target,
         orientation,
         panel.id,
         panel.widget,
-    ) catch return false;
+    ) catch {
+        ws.removePanel(panel.id);
+        ws.focused_panel_id = focused_id;
+        return false;
+    };
 
     // Rebuild the GTK widget tree
     rebuildWorkspaceWidget(tm, ws);
@@ -494,7 +496,7 @@ fn handleEqualizeSplits() bool {
 fn handleToggleSplitZoom() bool {
     // TODO: implement zoom by hiding sibling panes and restoring them
     log.info("toggle_split_zoom: not yet implemented", .{});
-    return true;
+    return false;
 }
 
 /// Find the Node (leaf or split) containing a panel by its ID.
@@ -538,16 +540,32 @@ fn rebuildWorkspaceWidget(tm: *@import("tab_manager.zig").TabManager, ws: *@impo
         }
     }
 
-    // Apply split ratios after widget is allocated
-    // Use an idle callback so GTK has time to allocate sizes
-    _ = c.gtk.g_idle_add(&applyRatiosIdle, root);
+    // Apply split ratios after widget is allocated.
+    // Use an idle callback so GTK has time to allocate sizes.
+    // Carry workspace ID (not raw pointer) to avoid use-after-free
+    // if the workspace is closed before the idle fires.
+    const alloc = std.heap.c_allocator;
+    const ctx = alloc.create(ApplyRatiosCtx) catch return;
+    ctx.* = .{ .ws_id = ws.id };
+    _ = c.gtk.g_idle_add(&applyRatiosIdle, ctx);
 }
+
+/// Context for deferred ratio application.
+const ApplyRatiosCtx = struct { ws_id: u128 };
 
 /// GLib idle callback to apply split ratios after allocation.
 /// Returns G_SOURCE_REMOVE so it only fires once.
 fn applyRatiosIdle(data: ?*anyopaque) callconv(.c) c.gtk.gboolean {
-    const root: *split_tree.Node = @ptrCast(@alignCast(data orelse return c.gtk.G_SOURCE_REMOVE));
-    split_tree.applyRatios(root);
+    const alloc = std.heap.c_allocator;
+    const ctx: *ApplyRatiosCtx = @ptrCast(@alignCast(data orelse return c.gtk.G_SOURCE_REMOVE));
+    defer alloc.destroy(ctx);
+    const tm = window.getTabManager() orelse return c.gtk.G_SOURCE_REMOVE;
+    for (tm.workspaces.items) |ws| {
+        if (ws.id == ctx.ws_id) {
+            if (ws.root_node) |r| split_tree.applyRatios(r);
+            break;
+        }
+    }
     return c.gtk.G_SOURCE_REMOVE;
 }
 

--- a/cmux-linux/src/split_tree.zig
+++ b/cmux-linux/src/split_tree.zig
@@ -225,12 +225,15 @@ pub fn collectLeaves(node: *Node, alloc: Allocator, out: *std.ArrayList(*Leaf)) 
     }
 }
 
+/// Direction for adjacent leaf navigation.
+pub const TraversalDirection = enum { next, previous };
+
 /// Find the next or previous leaf relative to the one with `panel_id`.
 /// `direction`: .next or .previous (wraps around).
 pub fn adjacentLeaf(
     root: *Node,
     panel_id: u128,
-    direction: enum { next, previous },
+    direction: TraversalDirection,
     alloc: Allocator,
 ) ?*Leaf {
     var leaves: std.ArrayList(*Leaf) = .empty;

--- a/cmux-linux/src/split_tree.zig
+++ b/cmux-linux/src/split_tree.zig
@@ -214,6 +214,75 @@ pub fn findResizeSplit(
     }
 }
 
+/// Collect all leaf nodes in left-to-right / top-to-bottom order.
+pub fn collectLeaves(node: *Node, alloc: Allocator, out: *std.ArrayList(*Leaf)) void {
+    switch (node.*) {
+        .leaf => |*leaf| out.append(alloc, leaf) catch {},
+        .split => |split| {
+            collectLeaves(split.first, alloc, out);
+            collectLeaves(split.second, alloc, out);
+        },
+    }
+}
+
+/// Find the next or previous leaf relative to the one with `panel_id`.
+/// `direction`: .next or .previous (wraps around).
+pub fn adjacentLeaf(
+    root: *Node,
+    panel_id: u128,
+    direction: enum { next, previous },
+    alloc: Allocator,
+) ?*Leaf {
+    var leaves: std.ArrayList(*Leaf) = .empty;
+    defer leaves.deinit(alloc);
+    collectLeaves(root, alloc, &leaves);
+    if (leaves.items.len <= 1) return null;
+
+    for (leaves.items, 0..) |leaf, i| {
+        if (leaf.panel_id == panel_id) {
+            return switch (direction) {
+                .next => leaves.items[(i + 1) % leaves.items.len],
+                .previous => leaves.items[if (i == 0) leaves.items.len - 1 else i - 1],
+            };
+        }
+    }
+    return null;
+}
+
+/// Set all split ratios to 0.5 (equalize).
+pub fn equalize(node: *Node) void {
+    switch (node.*) {
+        .leaf => {},
+        .split => |*split| {
+            split.ratio = 0.5;
+            equalize(split.first);
+            equalize(split.second);
+        },
+    }
+}
+
+/// Apply split ratios to GtkPaned widgets (call after widget allocation).
+pub fn applyRatios(node: *Node) void {
+    switch (node.*) {
+        .leaf => {},
+        .split => |*split| {
+            if (split.paned) |paned| {
+                // Get the allocated size along the split axis
+                const size: c_int = switch (split.orientation) {
+                    .horizontal => c.gtk.gtk_widget_get_width(paned),
+                    .vertical => c.gtk.gtk_widget_get_height(paned),
+                };
+                if (size > 0) {
+                    const pos: c_int = @intFromFloat(@as(f64, @floatFromInt(size)) * split.ratio);
+                    c.gtk.gtk_paned_set_position(@ptrCast(@alignCast(paned)), pos);
+                }
+            }
+            applyRatios(split.first);
+            applyRatios(split.second);
+        },
+    }
+}
+
 /// Recursively destroy all nodes.
 pub fn destroy(alloc: Allocator, node: *Node) void {
     switch (node.*) {

--- a/cmux-linux/src/split_tree.zig
+++ b/cmux-linux/src/split_tree.zig
@@ -217,7 +217,9 @@ pub fn findResizeSplit(
 /// Collect all leaf nodes in left-to-right / top-to-bottom order.
 pub fn collectLeaves(node: *Node, alloc: Allocator, out: *std.ArrayList(*Leaf)) void {
     switch (node.*) {
-        .leaf => |*leaf| out.append(alloc, leaf) catch {},
+        .leaf => |*leaf| out.append(alloc, leaf) catch |err| {
+            std.log.warn("collectLeaves: failed to append leaf: {}", .{err});
+        },
         .split => |split| {
             collectLeaves(split.first, alloc, out);
             collectLeaves(split.second, alloc, out);

--- a/cmux-linux/src/surface.zig
+++ b/cmux-linux/src/surface.zig
@@ -341,8 +341,10 @@ fn gtkModsToGhostty(state: c_uint) c.ghostty.ghostty_input_mods_e {
     if (state & c.gtk.GDK_ALT_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_ALT;
     if (state & c.gtk.GDK_SUPER_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_SUPER;
     if (state & c.gtk.GDK_LOCK_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_CAPS;
-    // GDK_MOD2_MASK is Num Lock on most Linux systems
-    if (state & c.gtk.GDK_MOD2_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_NUM;
+    // GDK_MOD2_MASK (0x10) is Num Lock on most Linux systems.
+    // Defined as a C macro, so not always visible through Zig's @cImport.
+    const GDK_MOD2_MASK: c_uint = 1 << 4;
+    if (state & GDK_MOD2_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_NUM;
     return @intCast(mods);
 }
 

--- a/cmux-linux/src/surface.zig
+++ b/cmux-linux/src/surface.zig
@@ -220,10 +220,18 @@ pub const Surface = struct {
             c.gtk.gdk_keyval_to_lower(keyval),
         );
 
+        // Determine consumed mods: if text was produced and the keyval
+        // differs from its lowercase form, shift was consumed to produce
+        // the character (e.g., Shift+a → "A").
+        var consumed: c_int = c.ghostty.GHOSTTY_MODS_NONE;
+        if (text_len > 0 and keyval != c.gtk.gdk_keyval_to_lower(keyval)) {
+            consumed |= c.ghostty.GHOSTTY_MODS_SHIFT;
+        }
+
         const key_event = c.ghostty.ghostty_input_key_s{
             .action = @intCast(action),
             .mods = mods,
-            .consumed_mods = c.ghostty.GHOSTTY_MODS_NONE,
+            .consumed_mods = @intCast(consumed),
             .keycode = keycode,
             .text = text_ptr,
             .unshifted_codepoint = unshifted_codepoint,
@@ -333,6 +341,8 @@ fn gtkModsToGhostty(state: c_uint) c.ghostty.ghostty_input_mods_e {
     if (state & c.gtk.GDK_ALT_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_ALT;
     if (state & c.gtk.GDK_SUPER_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_SUPER;
     if (state & c.gtk.GDK_LOCK_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_CAPS;
+    // GDK_MOD2_MASK is Num Lock on most Linux systems
+    if (state & c.gtk.GDK_MOD2_MASK != 0) mods |= c.ghostty.GHOSTTY_MODS_NUM;
     return @intCast(mods);
 }
 


### PR DESCRIPTION
## Summary

- Implement split pane management actions: new split, goto split, resize split, equalize splits, toggle split zoom (stub)
- Add move_tab action for keybind-driven tab reordering via AdwTabView
- Fix split tree update on surface close (shell exit / close-surface callback) — promotes sibling node and rebuilds widget tree
- Add consumed_mods logic for shift key and Num Lock modifier translation
- Define GDK_MOD2_MASK locally (C macro not visible through Zig's @cImport)

## Greptile findings addressed

- **P1**: Use-after-free in `applyRatiosIdle` — carry workspace ID instead of raw pointer
- **P1**: Orphaned panel when `splitPane` fails — find target node before creating panel, clean up on error
- **P1**: `buildWidget` called before leaf widgets are unparented — close old tab page and detach leaves from old GtkPaneds first
- **P1**: Resize delta uses hardcoded 1000px divisor — use actual pane size from `gtk_widget_get_width/height`
- **P2**: `toggle_split_zoom` returned true before implemented — changed to return false
- **P2**: `collectLeaves` silently drops leaves on OOM — added `log.warn`

## Test plan

- [ ] CI passes on all distros (Arch, Debian, Ubuntu, Fedora, Rocky)
- [ ] Nix flake check passes
- [ ] Manual smoke test on honey: split pane, navigate, resize, close pane, close surface