### PR TITLE
ci(nix): use runner nix on self-hosted lanes

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -419,6 +419,14 @@ jobs:
           echo "Generated local release-artifacts override:"
           cat nix/release-artifacts.override.nix
 
+      - name: Configure self-hosted Nix
+        run: bash scripts/configure-self-hosted-nix.sh
+
+      - name: Verify runner Nix daemon
+        run: |
+          nix --version
+          nix store info --store daemon
+
       - name: Verify KVM access
         run: |
           echo "=== KVM device ==="
@@ -435,13 +443,13 @@ jobs:
           fi
 
       - name: Rocky 9 package test (RPM proxy)
-        run: nix build .#checks.x86_64-linux.distro-rocky9 --print-build-logs -L --option sandbox relaxed
+        run: nix --store daemon build .#checks.x86_64-linux.distro-rocky9 --print-build-logs -L --option sandbox relaxed
 
       - name: Debian 12 package test
-        run: nix build .#checks.x86_64-linux.distro-debian12 --print-build-logs -L --option sandbox relaxed
+        run: nix --store daemon build .#checks.x86_64-linux.distro-debian12 --print-build-logs -L --option sandbox relaxed
 
       - name: Ubuntu 24.04 package test
-        run: nix build .#checks.x86_64-linux.distro-ubuntu2404 --print-build-logs -L --option sandbox relaxed
+        run: nix --store daemon build .#checks.x86_64-linux.distro-ubuntu2404 --print-build-logs -L --option sandbox relaxed
 
       - name: Upload distro validation logs
         if: always()

--- a/.github/workflows/release-qcow2.yml
+++ b/.github/workflows/release-qcow2.yml
@@ -50,9 +50,17 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Building QCOW2 ${{ matrix.variant }} for $TAG (version $VERSION)"
 
+      - name: Configure self-hosted Nix
+        run: bash scripts/configure-self-hosted-nix.sh
+
+      - name: Verify runner Nix daemon
+        run: |
+          nix --version
+          nix store info --store daemon
+
       - name: Build QCOW2 image
         run: |
-          nix build .#qcow2-${{ matrix.variant }} \
+          nix --store daemon build .#qcow2-${{ matrix.variant }} \
             --print-build-logs -L \
             --option sandbox relaxed
 

--- a/.github/workflows/test-cjk.yml
+++ b/.github/workflows/test-cjk.yml
@@ -37,15 +37,13 @@ jobs:
       - name: Setup GloriousFlywheel
         uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+      - name: Configure self-hosted Nix
+        run: bash scripts/configure-self-hosted-nix.sh
 
-      - name: Verify runner Nix toolchain
-        run: nix --version
+      - name: Verify runner Nix daemon
+        run: |
+          nix --version
+          nix store info --store daemon
 
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true
@@ -67,15 +65,15 @@ jobs:
 
       - name: Build libghostty (Nix)
         run: |
-          nix develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
+          nix --store daemon develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
           bash scripts/ghostty-compat-symlinks.sh
           ls -lh ghostty/zig-out/lib/libghostty.*
 
       - name: Build cmux-linux (Nix)
-        run: nix develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
+        run: nix --store daemon develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
 
       - name: Run CJK input tests
-        run: nix develop --command bash scripts/test-cjk-input.sh
+        run: nix --store daemon develop --command bash scripts/test-cjk-input.sh
 
       - name: Upload test logs
         if: always()

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -112,6 +112,14 @@ jobs:
           echo "Generated nix/release-artifacts.override.nix for ${TAG}"
           cat nix/release-artifacts.override.nix
 
+      - name: Configure self-hosted Nix
+        run: bash scripts/configure-self-hosted-nix.sh
+
+      - name: Verify runner Nix daemon
+        run: |
+          nix --version
+          nix store info --store daemon
+
       - name: Verify KVM access
         run: |
           echo "=== KVM device ==="
@@ -130,16 +138,16 @@ jobs:
 
       - name: Rocky 9 package test (RPM proxy)
         if: inputs.distro == 'all' || inputs.distro == 'rocky9' || inputs.distro == ''
-        run: nix build .#checks.x86_64-linux.distro-rocky9 --print-build-logs -L --option sandbox relaxed
+        run: nix --store daemon build .#checks.x86_64-linux.distro-rocky9 --print-build-logs -L --option sandbox relaxed
 
 
       - name: Debian 12 package test
         if: inputs.distro == 'all' || inputs.distro == 'debian12' || inputs.distro == ''
-        run: nix build .#checks.x86_64-linux.distro-debian12 --print-build-logs -L --option sandbox relaxed
+        run: nix --store daemon build .#checks.x86_64-linux.distro-debian12 --print-build-logs -L --option sandbox relaxed
 
       - name: Ubuntu 24.04 package test
         if: inputs.distro == 'all' || inputs.distro == 'ubuntu2404' || inputs.distro == ''
-        run: nix build .#checks.x86_64-linux.distro-ubuntu2404 --print-build-logs -L --option sandbox relaxed
+        run: nix --store daemon build .#checks.x86_64-linux.distro-ubuntu2404 --print-build-logs -L --option sandbox relaxed
 
       - name: Upload test logs
         if: always()

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -41,15 +41,13 @@ jobs:
       - name: Setup GloriousFlywheel
         uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+      - name: Configure self-hosted Nix
+        run: bash scripts/configure-self-hosted-nix.sh
 
-      - name: Verify runner Nix toolchain
-        run: nix --version
+      - name: Verify runner Nix daemon
+        run: |
+          nix --version
+          nix store info --store daemon
 
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true
@@ -63,20 +61,20 @@ jobs:
 
       - name: Build libghostty (Nix)
         run: |
-          nix develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
+          nix --store daemon develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
           bash scripts/ghostty-compat-symlinks.sh
           ls -lh ghostty/zig-out/lib/libghostty.*
 
       - name: Build cmux-linux (Nix)
-        run: nix develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
+        run: nix --store daemon develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
 
       - name: Test config parser (Nix)
-        run: nix develop --command bash -c 'cd cmux-linux && zig build test'
+        run: nix --store daemon develop --command bash -c 'cd cmux-linux && zig build test'
 
       - name: GPU smoke test
         env:
           SMOKE_TIMEOUT: ${{ inputs.test_timeout || '15' }}
-        run: nix develop --command bash scripts/smoke-test-gpu.sh "$SMOKE_TIMEOUT"
+        run: nix --store daemon develop --command bash scripts/smoke-test-gpu.sh "$SMOKE_TIMEOUT"
 
       - name: Upload crash logs
         if: failure()

--- a/.github/workflows/test-socket.yml
+++ b/.github/workflows/test-socket.yml
@@ -40,29 +40,28 @@ jobs:
       - name: Setup GloriousFlywheel
         uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+      - name: Configure self-hosted Nix
+        run: bash scripts/configure-self-hosted-nix.sh
 
-      - name: Verify runner Nix toolchain
-        run: nix --version
+      - name: Verify runner Nix daemon
+        run: |
+          nix --version
+          nix store info --store daemon
 
       - name: Strip non-version tags from ghostty
         run: git -C ghostty tag -l 'xcframework-*' | xargs git -C ghostty tag -d 2>/dev/null || true
 
       - name: Build libghostty (Nix)
         run: |
-          nix develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
+          nix --store daemon develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
           bash scripts/ghostty-compat-symlinks.sh
           ls -lh ghostty/zig-out/lib/libghostty.*
 
       - name: Build cmux-linux (Nix)
-        run: nix develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
+        run: nix --store daemon develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
 
       - name: Run socket tests
+        id: socket_tests
         continue-on-error: true
         env:
           TEST_FILTER: ${{ inputs.test_filter || '' }}
@@ -71,7 +70,13 @@ jobs:
           # candidates into BASELINE in the runner script. See cmux #216
           # / TIN-183 for the expansion plan.
           CMUX_TEST_PHASE1: '1'
-        run: nix develop --command bash scripts/run-socket-tests.sh
+        run: nix --store daemon develop --command bash scripts/run-socket-tests.sh
+
+      - name: Fail on baseline socket-test failure
+        if: ${{ always() && steps.socket_tests.outcome == 'failure' }}
+        run: |
+          echo "error: baseline socket tests failed; see the Run socket tests step and uploaded artifact." >&2
+          exit 1
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/test-ssh-proxy.yml
+++ b/.github/workflows/test-ssh-proxy.yml
@@ -53,19 +53,27 @@ jobs:
           docker info --format "Docker {{.ServerVersion}}"
           docker ps --format "Running containers: {{.Names}}" || true
 
+      - name: Configure self-hosted Nix
+        run: bash scripts/configure-self-hosted-nix.sh
+
+      - name: Verify runner Nix daemon
+        run: |
+          nix --version
+          nix store info --store daemon
+
       - name: Build libghostty (Nix)
         run: |
-          nix develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
+          nix --store daemon develop --command bash -c 'cd ghostty && zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast'
           bash scripts/ghostty-compat-symlinks.sh
           ls -lh ghostty/zig-out/lib/libghostty.*
 
       - name: Build cmux-linux (Nix)
-        run: nix develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
+        run: nix --store daemon develop --command bash -c 'cd cmux-linux && zig build -Doptimize=ReleaseFast && ls -lh zig-out/bin/cmux'
 
       - name: Run SSH proxy tests
         env:
           TEST_FILTER: ${{ inputs.test_filter || '' }}
-        run: nix develop --command bash scripts/run-ssh-proxy-tests.sh
+        run: nix --store daemon develop --command bash scripts/run-ssh-proxy-tests.sh
 
       - name: Upload test results
         if: always()

--- a/scripts/configure-self-hosted-nix.sh
+++ b/scripts/configure-self-hosted-nix.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "::error::Nix is not installed on this self-hosted runner." >&2
+  exit 1
+fi
+
+if [[ -z "${GITHUB_ENV:-}" ]]; then
+  echo "::error::GITHUB_ENV is not set; this script is meant to run inside GitHub Actions." >&2
+  exit 1
+fi
+
+ATTIC_PUBLIC_KEY="main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE="
+DETERMINATE_NIXD_LOG="/tmp/determinate-nixd.log"
+
+emit_github_env() {
+  local key="$1"
+  shift
+
+  {
+    printf '%s<<EOF\n' "$key"
+    printf '%s\n' "$@"
+    printf 'EOF\n'
+  } >>"$GITHUB_ENV"
+}
+
+daemon_store_available() {
+  nix store info --store daemon >/dev/null 2>&1
+}
+
+start_determinate_daemon() {
+  local daemon_bin
+  daemon_bin="$(command -v determinate-nixd)"
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    nohup "$daemon_bin" daemon >"$DETERMINATE_NIXD_LOG" 2>&1 &
+    return 0
+  fi
+
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "::error::determinate-nixd requires root to launch the daemon, but sudo is unavailable on this runner" >&2
+    return 1
+  fi
+
+  if ! sudo -n true >/dev/null 2>&1; then
+    echo "::error::Passwordless sudo is unavailable for launching determinate-nixd on this runner" >&2
+    return 1
+  fi
+
+  nohup sudo -n "$daemon_bin" daemon >"$DETERMINATE_NIXD_LOG" 2>&1 &
+}
+
+emit_diagnostics() {
+  echo "::notice::Nix daemon socket diagnostics"
+  for path in \
+    /nix/var/nix/daemon-socket \
+    /nix/var/nix/daemon-socket/socket \
+    /nix/var/determinate/determinate-nixd.socket \
+    /var/run/nix-daemon.socket \
+    /var/run/determinate-nixd.socket
+  do
+    if [[ -e "$path" || -L "$path" ]]; then
+      ls -ld "$path" >&2
+    else
+      echo "missing: $path" >&2
+    fi
+  done
+
+  if command -v ps >/dev/null 2>&1; then
+    ps -ef | grep '[d]eterminate-nixd' >&2 || true
+  fi
+}
+
+determine_daemon_mode() {
+  if daemon_store_available; then
+    echo "NIX_REMOTE=daemon" >>"$GITHUB_ENV"
+    echo "::notice::Using preinitialized Nix daemon"
+    return 0
+  fi
+
+  if command -v determinate-nixd >/dev/null 2>&1; then
+    echo "::notice::Starting determinate-nixd for this workflow"
+    rm -f "$DETERMINATE_NIXD_LOG"
+    start_determinate_daemon
+
+    local attempt
+    for attempt in $(seq 1 100); do
+      if daemon_store_available; then
+        echo "NIX_REMOTE=daemon" >>"$GITHUB_ENV"
+        echo "::notice::Determinate Nix daemon is ready"
+        return 0
+      fi
+      sleep 0.2
+    done
+
+    echo "::error::Determinate Nix daemon did not become ready" >&2
+    if [[ -f "$DETERMINATE_NIXD_LOG" ]]; then
+      sed -n '1,120p' "$DETERMINATE_NIXD_LOG" >&2
+    fi
+    emit_diagnostics
+    exit 1
+  fi
+
+  echo "::error::No usable Nix daemon detected on this self-hosted runner" >&2
+  emit_diagnostics
+  exit 1
+}
+
+determine_daemon_mode
+
+declare -a nix_config_lines=()
+if [[ -n "${NIX_CONFIG:-}" ]]; then
+  nix_config_lines+=("${NIX_CONFIG}")
+fi
+
+if [[ -n "${ATTIC_SERVER:-}" && -n "${ATTIC_CACHE:-}" ]]; then
+  nix_config_lines+=("extra-substituters = ${ATTIC_SERVER%/}/${ATTIC_CACHE}")
+  nix_config_lines+=("extra-trusted-public-keys = ${ATTIC_PUBLIC_KEY}")
+  echo "::notice::Configured Nix substituter ${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+fi
+
+if (( ${#nix_config_lines[@]} > 0 )); then
+  emit_github_env "NIX_CONFIG" "${nix_config_lines[@]}"
+fi
+
+echo "::notice::Using Nix from $(command -v nix)"
+nix --version

--- a/scripts/run-socket-tests.sh
+++ b/scripts/run-socket-tests.sh
@@ -30,6 +30,35 @@ FILTER="${TEST_FILTER:-}"
 STDERR_LOG="/tmp/socket-tests-stderr.log"
 TAP_FILE="/tmp/socket-tests-results.tap"
 
+resolve_nix_interpreter() {
+  if [ -n "${NIX_LD:-}" ] && [ -e "${NIX_LD}" ]; then
+    printf '%s\n' "${NIX_LD}"
+    return 0
+  fi
+
+  if [ -n "${NIX_CC:-}" ] && [ -r "${NIX_CC}/nix-support/dynamic-linker" ]; then
+    head -n 1 "${NIX_CC}/nix-support/dynamic-linker"
+    return 0
+  fi
+
+  if command -v cc >/dev/null 2>&1; then
+    local cc_path cc_root
+    cc_path="$(command -v cc)"
+    cc_root="${cc_path%/bin/cc}"
+    if [ -r "${cc_root}/nix-support/dynamic-linker" ]; then
+      head -n 1 "${cc_root}/nix-support/dynamic-linker"
+      return 0
+    fi
+  fi
+
+  if compgen -G "/nix/store/*glibc*/lib/ld-linux-x86-64.so.2" >/dev/null; then
+    ls /nix/store/*glibc*/lib/ld-linux-x86-64.so.2 2>/dev/null | sort -V | tail -1
+    return 0
+  fi
+
+  return 1
+}
+
 cleanup() {
   [ -n "${CMUX_PID:-}" ] && kill -9 "$CMUX_PID" 2>/dev/null || true
   [ -n "${XVFB_PID:-}" ] && kill -9 "$XVFB_PID" 2>/dev/null || true
@@ -39,8 +68,9 @@ trap cleanup EXIT
 
 # Prepend ghostty lib
 export LD_LIBRARY_PATH="$REPO_ROOT/ghostty/zig-out/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-# patchelf the binary to use Nix's glibc interpreter (host glibc is too old for WebKitGTK)
-NIX_INTERP=$(ls /nix/store/*glibc*/lib/ld-linux-x86-64.so.2 2>/dev/null | tail -1)
+# patchelf the binary to use the active Nix shell's dynamic linker.
+# Falling back to an arbitrary /nix/store glibc path can select the wrong ABI.
+NIX_INTERP="$(resolve_nix_interpreter || true)"
 if [ -n "$NIX_INTERP" ] && command -v patchelf &>/dev/null; then
   echo "Patching interpreter: $NIX_INTERP"
   patchelf --set-interpreter "$NIX_INTERP" "$BINARY" 2>/dev/null || true

--- a/scripts/run-ssh-proxy-tests.sh
+++ b/scripts/run-ssh-proxy-tests.sh
@@ -11,6 +11,35 @@ FILTER="${TEST_FILTER:-}"
 STDERR_LOG="/tmp/ssh-proxy-tests-stderr.log"
 TAP_FILE="/tmp/ssh-proxy-tests-results.tap"
 
+resolve_nix_interpreter() {
+  if [ -n "${NIX_LD:-}" ] && [ -e "${NIX_LD}" ]; then
+    printf '%s\n' "${NIX_LD}"
+    return 0
+  fi
+
+  if [ -n "${NIX_CC:-}" ] && [ -r "${NIX_CC}/nix-support/dynamic-linker" ]; then
+    head -n 1 "${NIX_CC}/nix-support/dynamic-linker"
+    return 0
+  fi
+
+  if command -v cc >/dev/null 2>&1; then
+    local cc_path cc_root
+    cc_path="$(command -v cc)"
+    cc_root="${cc_path%/bin/cc}"
+    if [ -r "${cc_root}/nix-support/dynamic-linker" ]; then
+      head -n 1 "${cc_root}/nix-support/dynamic-linker"
+      return 0
+    fi
+  fi
+
+  if compgen -G "/nix/store/*glibc*/lib/ld-linux-x86-64.so.2" >/dev/null; then
+    ls /nix/store/*glibc*/lib/ld-linux-x86-64.so.2 2>/dev/null | sort -V | tail -1
+    return 0
+  fi
+
+  return 1
+}
+
 cleanup() {
   [ -n "${CMUX_PID:-}" ] && kill -9 "$CMUX_PID" 2>/dev/null || true
   [ -n "${XVFB_PID:-}" ] && kill -9 "$XVFB_PID" 2>/dev/null || true
@@ -36,8 +65,8 @@ fi
 
 # Prepend ghostty lib
 export LD_LIBRARY_PATH="$REPO_ROOT/ghostty/zig-out/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-# patchelf for Nix glibc
-NIX_INTERP=$(ls /nix/store/*glibc*/lib/ld-linux-x86-64.so.2 2>/dev/null | tail -1)
+# patchelf for the active Nix shell's dynamic linker.
+NIX_INTERP="$(resolve_nix_interpreter || true)"
 if [ -n "$NIX_INTERP" ] && command -v patchelf &>/dev/null; then
   echo "Patching interpreter: $NIX_INTERP"
   patchelf --set-interpreter "$NIX_INTERP" "$BINARY" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add a shared self-hosted Nix bootstrap script for runner-owned daemon mode
- switch the self-hosted socket, gpu, cjk, distro, ssh-proxy, and release lanes to use the runner Nix daemon instead of assuming a writable single-user store
- make the socket and ssh-proxy scripts resolve the active Nix dynamic linker instead of guessing an arbitrary glibc path

## Validation
- workflow YAML parse
- `bash -n scripts/configure-self-hosted-nix.sh scripts/run-socket-tests.sh scripts/run-ssh-proxy-tests.sh`
- `git diff --check`
- previous `main` failure boundary on this fork: run `24747790637` failed immediately at `Build libghostty (Nix)` with `/nix/var/nix/db/big-lock: Permission denied`
- fresh branch proof will be re-dispatched on this narrowed head

## Context
This is the narrowed restack of the larger `codex/socket-ci-truthfulness` branch. The goal is to land the self-hosted runner contract fix on the real fork base without pulling in unrelated socket/runtime feature work.
