### PR TITLE
ci: lint Linux packaging drafts

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -35,7 +35,11 @@ jobs:
         id: check-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHOSTTY_RELEASE_TOKEN: ${{ secrets.GHOSTTY_RELEASE_TOKEN }}
         run: |
+          if [ -n "${GHOSTTY_RELEASE_TOKEN:-}" ]; then
+            export GH_TOKEN="$GHOSTTY_RELEASE_TOKEN"
+          fi
           TAG="xcframework-${{ steps.ghostty-sha.outputs.sha }}"
           if gh release view "$TAG" --repo Jesssullivan/ghostty >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -110,6 +114,10 @@ jobs:
             exit 0
           fi
           TAG="xcframework-${{ steps.ghostty-sha.outputs.sha }}"
+          if gh release view "$TAG" --repo Jesssullivan/ghostty >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping upload"
+            exit 0
+          fi
           gh release create "$TAG" \
             --repo Jesssullivan/ghostty \
             --title "GhosttyKit xcframework (${{ steps.ghostty-sha.outputs.sha }})" \

--- a/.github/workflows/package-draft-lint.yml
+++ b/.github/workflows/package-draft-lint.yml
@@ -1,0 +1,64 @@
+name: Package Draft Lint
+
+on:
+  push:
+    branches: [main, 'sid/**']
+    paths:
+      - 'packaging/**'
+      - '.github/workflows/package-draft-lint.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packaging/**'
+      - '.github/workflows/package-draft-lint.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: package-draft-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  aur-pkgbuild:
+    name: AUR PKGBUILD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate PKGBUILD metadata
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD/packaging/aur:/workspace:ro" \
+            archlinux:base-devel \
+            bash -lc '
+              set -euo pipefail
+              useradd -m builder
+              install -d -o builder -g builder /tmp/aur
+              cp /workspace/PKGBUILD /tmp/aur/PKGBUILD
+              chown builder:builder /tmp/aur/PKGBUILD
+              su builder -c "cd /tmp/aur && makepkg --printsrcinfo > /tmp/cmux.SRCINFO"
+              test -s /tmp/cmux.SRCINFO
+              grep -q "^pkgname = cmux$" /tmp/cmux.SRCINFO
+            '
+
+  copr-spec:
+    name: COPR spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate RPM spec expansion
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD/packaging/copr:/workspace:ro" \
+            fedora:42 \
+            bash -lc '
+              set -euo pipefail
+              dnf -y install rpm-build systemd-rpm-macros >/dev/null
+              rpmspec -P /workspace/cmux.spec > /tmp/cmux.webkit.spec
+              rpmspec -P --without webkit /workspace/cmux.spec > /tmp/cmux.no-webkit.spec
+              test -s /tmp/cmux.webkit.spec
+              test -s /tmp/cmux.no-webkit.spec
+              grep -q "^Name: *cmux$" /tmp/cmux.webkit.spec
+            '

--- a/.github/workflows/package-draft-lint.yml
+++ b/.github/workflows/package-draft-lint.yml
@@ -22,14 +22,14 @@ jobs:
     name: AUR PKGBUILD
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate PKGBUILD metadata
         run: |
           set -euo pipefail
           docker run --rm \
             -v "$PWD/packaging/aur:/workspace:ro" \
-            archlinux:base-devel \
+            archlinux:base-devel@sha256:f15064b187aea96308a0252d1eacf514a2ee89aad6d44811f52b733fa9a5e42b \
             bash -lc '
               set -euo pipefail
               useradd -m builder
@@ -45,14 +45,14 @@ jobs:
     name: COPR spec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate RPM spec expansion
         run: |
           set -euo pipefail
           docker run --rm \
             -v "$PWD/packaging/copr:/workspace:ro" \
-            fedora:42 \
+            fedora:42@sha256:eb167a7adffa1489a205c83a7b9324e4cb0fae5c54645f263e70ac13f661f0e8 \
             bash -lc '
               set -euo pipefail
               dnf -y install rpm-build systemd-rpm-macros >/dev/null
@@ -61,4 +61,17 @@ jobs:
               test -s /tmp/cmux.webkit.spec
               test -s /tmp/cmux.no-webkit.spec
               grep -q "^Name: *cmux$" /tmp/cmux.webkit.spec
+
+              buildroot="$(mktemp -d)"
+              install -Dm755 /dev/null "$buildroot/usr/bin/cmux"
+              install -Dm755 /dev/null "$buildroot/usr/lib64/cmux/libghostty.so"
+              install -Dm644 /dev/null "$buildroot/usr/share/applications/com.jesssullivan.cmux.desktop"
+              install -Dm644 /dev/null "$buildroot/usr/share/metainfo/com.jesssullivan.cmux.metainfo.xml"
+              install -Dm644 /dev/null "$buildroot/usr/lib/udev/rules.d/70-u2f.rules"
+              install -Dm644 /dev/null "$buildroot/usr/share/licenses/cmux/LICENSE"
+              install -Dm644 /dev/null "$buildroot/usr/share/doc/cmux/README.md"
+              for size in 16 128 256 512; do
+                install -Dm644 /dev/null "$buildroot/usr/share/icons/hicolor/${size}x${size}/apps/com.jesssullivan.cmux.png"
+              done
+              rpmbuild -bl --nodeps --buildroot "$buildroot" /workspace/cmux.spec >/tmp/cmux.files.log
             '

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -50,9 +50,6 @@ build() {
   bash scripts/ghostty-compat-symlinks.sh
 
   (cd cmux-linux && zig build -Doptimize=ReleaseFast)
-  if [[ -d cmuxd ]]; then
-    (cd cmuxd && zig build -Doptimize=ReleaseFast)
-  fi
 }
 
 package() {
@@ -60,9 +57,6 @@ package() {
 
   install -Dm755 cmux-linux/zig-out/bin/cmux "${pkgdir}/usr/bin/cmux"
   install -Dm755 ghostty/zig-out/lib/libghostty.so "${pkgdir}/usr/lib/cmux/libghostty.so"
-  if [[ -f cmuxd/zig-out/bin/cmuxd ]]; then
-    install -Dm755 cmuxd/zig-out/bin/cmuxd "${pkgdir}/usr/bin/cmuxd"
-  fi
 
   install -Dm644 dist/linux/com.jesssullivan.cmux.desktop \
     "${pkgdir}/usr/share/applications/com.jesssullivan.cmux.desktop"

--- a/packaging/copr/cmux.spec
+++ b/packaging/copr/cmux.spec
@@ -77,18 +77,9 @@ zig build -Doptimize=ReleaseFast -Dno-webkit=true
 %endif
 popd
 
-if [ -d cmuxd ]; then
-  pushd cmuxd
-  zig build -Doptimize=ReleaseFast
-  popd
-fi
-
 %install
 install -Dm755 cmux-linux/zig-out/bin/cmux %{buildroot}%{_bindir}/cmux
 install -Dm755 ghostty/zig-out/lib/libghostty.so %{buildroot}%{_libdir}/cmux/libghostty.so
-if [ -f cmuxd/zig-out/bin/cmuxd ]; then
-  install -Dm755 cmuxd/zig-out/bin/cmuxd %{buildroot}%{_bindir}/cmuxd
-fi
 install -Dm644 dist/linux/com.jesssullivan.cmux.desktop %{buildroot}%{_datadir}/applications/com.jesssullivan.cmux.desktop
 install -Dm644 dist/linux/com.jesssullivan.cmux.metainfo.xml %{buildroot}%{_datadir}/metainfo/com.jesssullivan.cmux.metainfo.xml
 for size in 16 128 256 512; do
@@ -112,7 +103,6 @@ install -Dm644 README.md %{buildroot}%{_docdir}/%{name}/README.md
 %license %{_licensedir}/%{name}/LICENSE
 %doc %{_docdir}/%{name}/README.md
 %{_bindir}/cmux
-%{_bindir}/cmuxd
 %{_libdir}/cmux/libghostty.so
 %{_datadir}/applications/com.jesssullivan.cmux.desktop
 %{_datadir}/metainfo/com.jesssullivan.cmux.metainfo.xml


### PR DESCRIPTION
## Summary

- add a Package Draft Lint workflow for the Linux AUR and COPR scaffolds
- validate the AUR PKGBUILD with Arch makepkg metadata generation
- validate the COPR RPM spec with Fedora rpmspec expansion and an RPM `%files` manifest check
- remove stale optional `cmuxd` package entries from the AUR/COPR drafts because this checkout does not contain `cmuxd`
- make the GhosttyKit prebuilt release workflow idempotent when the target `Jesssullivan/ghostty` release already exists

## Validation

- `ruby -e 'require "yaml"; YAML.load_file("/tmp/cmux-pr245/.github/workflows/package-draft-lint.yml")'`
- `ruby -e 'require "yaml"; YAML.load_file("/tmp/cmux-pr245/.github/workflows/build-ghosttykit.yml")'`
- `git diff --cached --check`
- refreshed PR run after `f90fa4a8`: `build-ghosttykit`, `AUR PKGBUILD`, and `COPR spec` passed
- local Docker replay for the widened COPR command was attempted, but the local Docker daemon failed during Fedora image pull with `unable to upgrade to tcp, received 500`; CI is the validator for the final container path

## Notes

- This completes the missing CI-lint piece of TIN-181 once the final refreshed PR check set passes.
- The earlier GhosttyKit failure was unrelated to the packaging lint: the build succeeded, then `gh release create` failed because the release tag already existed.
