### PR TITLE
[codex] Centralize Zig resolution for build scripts

### DIFF
--- a/scripts/build-ghostty-cli-helper.sh
+++ b/scripts/build-ghostty-cli-helper.sh
@@ -16,6 +16,7 @@ EOF
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 GHOSTTY_DIR="$REPO_ROOT/ghostty"
+ZIG_BIN="$("$SCRIPT_DIR/resolve-zig.sh")"
 
 OUTPUT_PATH=""
 TARGET_TRIPLE=""
@@ -83,16 +84,11 @@ if [[ -n "$TARGET_TRIPLE" ]]; then
   # so zig uses native compilation. This avoids cross-linker issues on newer
   # SDKs (e.g., macOS Tahoe + zig 0.15.x). Note: zig may run under Rosetta,
   # so we detect native output arch from the zig binary itself, not uname -m.
-  ZIG_ARCH="$(file "$(command -v zig)" 2>/dev/null | grep -oE '(arm64|x86_64)' | head -1)"
+  ZIG_ARCH="$(file "$ZIG_BIN" 2>/dev/null | grep -oE '(arm64|x86_64)' | head -1)"
   case "$TARGET_TRIPLE" in
     aarch64-macos) [[ "$ZIG_ARCH" == "arm64" ]] && TARGET_TRIPLE="" ;;
     x86_64-macos)  [[ "$ZIG_ARCH" == "x86_64" ]] && TARGET_TRIPLE="" ;;
   esac
-fi
-
-if ! command -v zig >/dev/null 2>&1; then
-  echo "error: zig is required to build the Ghostty CLI helper" >&2
-  exit 1
 fi
 
 if [[ ! -f "$GHOSTTY_DIR/build.zig" ]]; then
@@ -104,7 +100,7 @@ build_helper() {
   local prefix="$1"
   local target="${2:-}"
   local args=(
-    zig build
+    "$ZIG_BIN" build
     cli-helper
     -Dapp-runtime=none
     -Demit-macos-app=false
@@ -132,7 +128,7 @@ mkdir -p "$(dirname "$OUTPUT_PATH")"
 if [[ "$UNIVERSAL" == "true" ]]; then
   ARM64_PREFIX="$TMP_DIR/arm64"
   X86_PREFIX="$TMP_DIR/x86_64"
-  ZIG_ARCH="$(file "$(command -v zig)" 2>/dev/null | grep -oE '(arm64|x86_64)' | head -1)"
+  ZIG_ARCH="$(file "$ZIG_BIN" 2>/dev/null | grep -oE '(arm64|x86_64)' | head -1)"
   # Use native compilation for the matching arch to avoid cross-linker issues
   if [[ "$ZIG_ARCH" == "arm64" ]]; then
     build_helper "$ARM64_PREFIX" ""

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ZIG_BIN="$("$SCRIPT_DIR/resolve-zig.sh")"
+
 # Build, sign, notarize, create DMG, generate appcast, and upload to GitHub release.
 # Usage: ./scripts/build-sign-upload.sh <tag> [--allow-overwrite]
 # Requires: source ~/.secrets/cmuxterm.env && export SPARKLE_PRIVATE_KEY
@@ -54,7 +57,7 @@ APP_PATH="build/Build/Products/Release/cmux.app"
 # --- Pre-flight ---
 source ~/.secrets/cmuxterm.env
 export SPARKLE_PRIVATE_KEY
-for tool in zig xcodebuild create-dmg xcrun codesign ditto gh; do
+for tool in xcodebuild create-dmg xcrun codesign ditto gh; do
   command -v "$tool" >/dev/null || { echo "MISSING: $tool" >&2; exit 1; }
 done
 echo "Pre-flight checks passed"
@@ -62,7 +65,7 @@ echo "Pre-flight checks passed"
 # --- Build GhosttyKit (if needed) ---
 if [ ! -d "GhosttyKit.xcframework" ]; then
   echo "Building GhosttyKit..."
-  cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast && cd ..
+  cd ghostty && "$ZIG_BIN" build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast && cd ..
   rm -rf GhosttyKit.xcframework
   cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
 else

--- a/scripts/ensure-ghosttykit.sh
+++ b/scripts/ensure-ghosttykit.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ZIG_BIN="$("$SCRIPT_DIR/resolve-zig.sh")"
 
 cd "$PROJECT_DIR"
 
@@ -55,12 +56,6 @@ PY
 
 if [[ ! -d "$PROJECT_DIR/ghostty" ]]; then
   echo "error: ghostty submodule is missing. Run ./scripts/setup.sh first." >&2
-  exit 1
-fi
-
-if ! command -v zig >/dev/null 2>&1; then
-  echo "Error: zig is not installed." >&2
-  echo "Install via: brew install zig" >&2
   exit 1
 fi
 
@@ -219,7 +214,7 @@ else
     echo "==> Building GhosttyKit.xcframework (this may take a few minutes)..."
     (
       cd ghostty
-      zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+      "$ZIG_BIN" build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
     )
     echo "$GHOSTTY_KEY" > "$LOCAL_KEY_STAMP"
     echo "$GHOSTTY_SHA" > "$LEGACY_LOCAL_SHA_STAMP"

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 APP_NAME="cmux DEV"
 BUNDLE_ID="com.cmuxterm.app.debug"
 BASE_APP_NAME="cmux DEV"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ZIG_BIN="$("$SCRIPT_DIR/resolve-zig.sh")"
 DERIVED_DATA=""
 NAME_SET=0
 BUNDLE_SET=0
@@ -24,7 +26,7 @@ should_skip_ghostty_cli_helper_zig_build() {
 
   local product_version zig_version major_version
   product_version="$(sw_vers -productVersion 2>/dev/null || true)"
-  zig_version="$(zig version 2>/dev/null || true)"
+  zig_version="$("$ZIG_BIN" version 2>/dev/null || true)"
   major_version="${product_version%%.*}"
 
   if [[ "$zig_version" == "0.15.2" ]] && [[ "$major_version" =~ ^[0-9]+$ ]] && (( major_version >= 26 )); then
@@ -281,7 +283,7 @@ if [[ -z "$TAG" ]]; then
   exit 1
 fi
 
-"$PWD/scripts/ensure-ghosttykit.sh"
+"$SCRIPT_DIR/ensure-ghosttykit.sh"
 
 if should_skip_ghostty_cli_helper_zig_build; then
   if [[ "${CMUX_SKIP_ZIG_BUILD:-}" != "1" ]]; then
@@ -325,6 +327,7 @@ fi
 if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
   XCODEBUILD_ARGS+=(CMUX_SKIP_ZIG_BUILD=1)
 fi
+XCODEBUILD_ARGS+=(CMUX_ZIG_BIN="$ZIG_BIN")
 XCODEBUILD_ARGS+=(build)
 
 XCODE_LOG="/tmp/cmux-xcodebuild-${TAG_SLUG}.log"
@@ -505,13 +508,13 @@ fi
 CMUXD_SRC="$PWD/cmuxd/zig-out/bin/cmuxd"
 GHOSTTY_HELPER_SRC="$PWD/ghostty/zig-out/bin/ghostty"
 if [[ -d "$PWD/cmuxd" ]]; then
-  (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
+  (cd "$PWD/cmuxd" && "$ZIG_BIN" build -Doptimize=ReleaseFast)
 fi
 if [[ -d "$PWD/ghostty" ]]; then
   if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
     echo "Skipping direct ghostty CLI helper zig build (CMUX_SKIP_ZIG_BUILD=1)"
   else
-    (cd "$PWD/ghostty" && zig build cli-helper -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Doptimize=ReleaseFast)
+    (cd "$PWD/ghostty" && "$ZIG_BIN" build cli-helper -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Doptimize=ReleaseFast)
   fi
 fi
 if [[ -x "$CMUXD_SRC" ]]; then

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 APP_NAME="cmux STAGING"
 BUNDLE_ID="com.cmuxterm.app.staging"
 BASE_APP_NAME="cmux"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ZIG_BIN="$("$SCRIPT_DIR/resolve-zig.sh")"
 DERIVED_DATA=""
 NAME_SET=0
 BUNDLE_SET=0
@@ -227,7 +229,7 @@ pkill -f "${APP_NAME}.app/Contents/MacOS/${BASE_APP_NAME}" || true
 sleep 0.3
 CMUXD_SRC="$PWD/cmuxd/zig-out/bin/cmuxd"
 if [[ -d "$PWD/cmuxd" ]]; then
-  (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
+  (cd "$PWD/cmuxd" && "$ZIG_BIN" build -Doptimize=ReleaseFast)
 fi
 if [[ -x "$CMUXD_SRC" ]]; then
   BIN_DIR="$APP_PATH/Contents/Resources/bin"

--- a/scripts/resolve-zig.sh
+++ b/scripts/resolve-zig.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prefer an explicitly managed Zig install over whatever happens to appear
+# first on PATH. This avoids local Nix profiles shadowing the repo's intended
+# Zig version during Xcode/script-driven builds.
+
+if [[ -n "${CMUX_ZIG_BIN:-}" ]]; then
+  if [[ -x "${CMUX_ZIG_BIN}" ]]; then
+    printf '%s\n' "${CMUX_ZIG_BIN}"
+    exit 0
+  fi
+  echo "error: CMUX_ZIG_BIN is set but not executable: ${CMUX_ZIG_BIN}" >&2
+  exit 1
+fi
+
+declare -a candidates=(
+  "/usr/local/bin/zig"
+  "/opt/homebrew/bin/zig"
+  "$HOME/.local/zig/zig"
+)
+
+for candidate in "${candidates[@]}"; do
+  if [[ -x "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    exit 0
+  fi
+done
+
+if command -v zig >/dev/null 2>&1; then
+  command -v zig
+  exit 0
+fi
+
+echo "error: zig is required but was not found." >&2
+echo "hint: install Zig 0.15.2 or set CMUX_ZIG_BIN=/abs/path/to/zig" >&2
+exit 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,11 +10,8 @@ echo "==> Initializing submodules..."
 git submodule update --init --recursive
 
 echo "==> Checking for zig..."
-if ! command -v zig &> /dev/null; then
-    echo "Error: zig is not installed."
-    echo "Install via: brew install zig"
-    exit 1
-fi
+ZIG_BIN="$("$SCRIPT_DIR/resolve-zig.sh")"
+echo "==> Using zig: $ZIG_BIN ($("$ZIG_BIN" version))"
 
 "$SCRIPT_DIR/ensure-ghosttykit.sh"
 


### PR DESCRIPTION
## Summary
- add scripts/resolve-zig.sh to honor CMUX_ZIG_BIN and prefer managed Zig installs before PATH
- route GhosttyKit, Ghostty CLI helper, cmuxd, reload/setup, and release-signing scripts through the resolved Zig binary
- forward CMUX_ZIG_BIN into tagged Xcode reload builds so run script phases use the same toolchain

## Validation
- bash -n scripts/resolve-zig.sh scripts/build-ghostty-cli-helper.sh scripts/build-sign-upload.sh scripts/ensure-ghosttykit.sh scripts/reload.sh scripts/reloads.sh scripts/setup.sh
- ./scripts/resolve-zig.sh -> /usr/local/bin/zig
- /usr/local/bin/zig version -> 0.15.2
- git diff --check
- repository policy says not to run local tests; CI should own runtime validation

## Notes
- Commit 6de096b1 was created with --no-gpg-sign because GPG signing timed out in this non-interactive session.
- Scope intentionally excludes Rocky/RPM workflow changes, Bonsplit pointer movement, and Zig vendor pin changes.