### PR TITLE
[codex] Document required merge checks

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -69,7 +69,7 @@ jobs:
             build
 
   nix-check:
-    name: Nix flake check
+    name: Fork Nix flake check
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   # ── Nix Flake: dev shell + checks ──────────────────────────────────
   nix-flake:
-    name: Nix flake check
+    name: Linux Nix flake check
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ Detailed execution belongs in owned trackers and status docs, not here.
 - [ ] Upstream ingestion
   - Sync `Jesssullivan/cmux` with the remaining `manaflow-ai/cmux` delta in controlled batches
   - Reconcile `vendor/bonsplit` tracking posture and decide whether the Jess fork or upstream `main` is the canonical pin source
-  - `TIN-621` bump cmux Zig vendor pins to productionized releases
   - Resync `homebrew-cmux` during the next release-hygiene pass
   - `TIN-619` require green checks before merging owned-fork PRs
 

--- a/docs/ci-governance.md
+++ b/docs/ci-governance.md
@@ -1,0 +1,81 @@
+# CI Governance
+
+This runbook defines the merge gate for `Jesssullivan/cmux`.
+
+It is intentionally scoped to owned-fork governance. It does not publish,
+comment on, or configure any third-party upstream repository.
+
+## Current Rule
+
+Normal PR merges into `main` should wait for the hosted required checks below
+to pass. Self-hosted proof lanes remain advisory until runner availability is
+steady enough that they can be required without blocking unrelated work.
+
+Do not use auto-merge as a substitute for branch protection. Auto-merge is only
+safe after GitHub itself knows which checks are required.
+
+## Required Hosted Checks
+
+Require these status checks for normal PRs into `main`:
+
+| Check | Workflow | Why |
+|---|---|---|
+| `build-ghosttykit` | `Build GhosttyKit` | proves the embedded macOS framework can be built or fetched for the pinned Ghostty commit |
+| `Build macOS (LAB)` | `Fork CI` | proves the macOS app still builds in Debug and Release |
+| `Fork Nix flake check` | `Fork CI` | proves the fork-wide Nix checks and best-effort socket/graphical checks still run |
+| `Linux Nix flake check` | `Linux CI` | proves the Linux flake checks remain healthy in the Linux workflow |
+| `Zig vendor libs (Linux)` | `Linux CI` | proves the Zig vendor libraries, `cmuxd`, `libghostty`, and Linux binary build path remain wired |
+| `Ubuntu 24.04 (broad-feature)` | `Linux CI` | primary broad-feature Linux build target |
+| `Fedora 42 (GTK4 4.18)` | `Linux CI` | primary current GTK/Fedora target |
+| `Debian 12 (baseline, no-webkit)` | `Linux CI` | conservative no-WebKit baseline target |
+| `Rocky Linux 10 (RHEL 10)` | `Linux CI` | terminal-first RHEL-family target |
+| `Arch Linux (bleeding edge)` | `Linux CI` | rolling distro compatibility signal |
+
+The two Nix jobs are deliberately named differently. Do not collapse them back
+to the same check name; duplicate status contexts make branch-protection
+configuration ambiguous.
+
+## Advisory Checks
+
+Keep these checks visible, but do not require them for every normal PR yet:
+
+| Check or workflow | Reason |
+|---|---|
+| `Distro Package Tests (Self-Hosted)` | depends on the `honey-cmux` KVM runner; it is the proof lane for Fedora/Rocky package installs, not a default merge blocker |
+| `Socket Tests (Self-Hosted Linux)` | useful Linux runtime evidence, but runner capacity and surface readiness are still being expanded |
+| `GPU Smoke Test (Self-Hosted)` | hardware-specific smoke coverage |
+| `CJK Input Tests (Self-Hosted)` | hardware/runner-specific input coverage |
+| `SSH Proxy E2E Tests (Self-Hosted)` | integration proof, not a default gate for unrelated changes |
+| `Flatpak CI` | path-filtered; requiring it globally would block PRs where the workflow legitimately does not run |
+| `Package Draft Lint` | path-filtered packaging lint; require per-PR by review judgment until a sentinel check exists |
+| `Greptile Review` | review signal, not a build or runtime proof |
+| `Claude Code` | comment/review automation; skipped runs should not block merges |
+
+If a path-filtered workflow should become required, first add a stable sentinel
+job that always reports success or failure for every PR. Then update this file
+and the branch-protection rule together.
+
+## Branch Protection Setup
+
+For `main`, configure either a GitHub ruleset or classic branch protection with:
+
+- pull requests required before merge
+- required status checks enabled
+- the required hosted checks listed above
+- stale approvals dismissed when new commits are pushed, if practical
+- admins included only if Jess wants the fork to prevent accidental manual
+  bypasses
+
+Leave self-hosted proof lanes advisory until `TIN-184` has repeated green runs
+and runner availability is no longer the dominant failure mode.
+
+## Operating Notes
+
+- `merge on greens` means the required hosted checks are green in GitHub, not
+  merely that an operator skimmed the Actions page.
+- If a required check is renamed, update the branch-protection rule and this
+  document in the same PR.
+- If a required workflow becomes path-filtered, add a sentinel job first or
+  remove that check from the required set.
+- Failed advisory checks should be triaged and linked to the relevant Linear or
+  GitHub proof issue, but they should not automatically block unrelated PRs.

--- a/docs/program-status.md
+++ b/docs/program-status.md
@@ -36,7 +36,8 @@ As of 2026-04-25:
   proof is still uneven across the distro matrix
 - CI runtime hygiene is medium: the Linux branch is green, but GitHub Actions
   runtime upkeep still needs steady attention as hosted actions deprecate older
-  Node versions
+  Node versions, and `main` branch protection still needs to be enforced after
+  the required check set is finalized
 
 ## Current Critical Path
 
@@ -168,6 +169,17 @@ Recent CI made the baseline contract useful but exposed one active baseline
 failure: `test_surface_action_close_variants`. That should be fixed or
 explicitly reclassified before promoting more candidate tests.
 
+### Merge governance
+
+`docs/ci-governance.md` defines the required hosted checks and advisory
+self-hosted lanes for `Jesssullivan/cmux`.
+
+Current gap:
+
+- `main` branch protection/rulesets still need to be enabled in GitHub
+- self-hosted KVM package-install proof remains advisory until `honey-cmux`
+  availability is stable enough to act as a normal merge gate
+
 ## Dependency And Package Health
 
 | Component | Status | Current read |
@@ -233,5 +245,7 @@ repo hygiene:
    triggers in `docs/distro-testing-readiness-plan.md` become real.
 6. Replace or isolate the remaining `mlugg/setup-zig@v2` call sites as a
    separate CI hygiene follow-up.
-7. Avoid opening new architectural lanes until the existing parity matrix is
+7. Enable `main` branch protection with the hosted required-check set in
+   `docs/ci-governance.md`.
+8. Avoid opening new architectural lanes until the existing parity matrix is
    promoted with real validation.


### PR DESCRIPTION
## Summary

- document the required hosted check set for `Jesssullivan/cmux` branch protection
- rename duplicate Nix job contexts so branch protection can distinguish Fork CI from Linux CI
- mark self-hosted and path-filtered workflows as advisory until they have stable sentinel coverage or runner availability
- remove completed `TIN-621` from the active TODO lane

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/fork-ci.yml .github/workflows/linux-ci.yml`

## Notes

- No local test suites were run per repo policy.
- Commit was created with `--no-gpg-sign` because GPG signing times out in this non-interactive session.
