### PR TITLE
[codex] Mark branch protection active

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,6 @@ Detailed execution belongs in owned trackers and status docs, not here.
   - Sync `Jesssullivan/cmux` with the remaining `manaflow-ai/cmux` delta in controlled batches
   - Reconcile `vendor/bonsplit` tracking posture and decide whether the Jess fork or upstream `main` is the canonical pin source
   - Resync `homebrew-cmux` during the next release-hygiene pass
-  - `TIN-619` require green checks before merging owned-fork PRs
 
 - [ ] Linux proof and parity
   - `TIN-614` record first signed DEB/RPM artifact proof

--- a/docs/ci-governance.md
+++ b/docs/ci-governance.md
@@ -11,6 +11,8 @@ Normal PR merges into `main` should wait for the hosted required checks below
 to pass. Self-hosted proof lanes remain advisory until runner availability is
 steady enough that they can be required without blocking unrelated work.
 
+As of 2026-04-26, this rule is active on `main` in `Jesssullivan/cmux`.
+
 Do not use auto-merge as a substitute for branch protection. Auto-merge is only
 safe after GitHub itself knows which checks are required.
 
@@ -55,16 +57,19 @@ If a path-filtered workflow should become required, first add a stable sentinel
 job that always reports success or failure for every PR. Then update this file
 and the branch-protection rule together.
 
-## Branch Protection Setup
+## Branch Protection State
 
-For `main`, configure either a GitHub ruleset or classic branch protection with:
+`main` uses classic branch protection with:
 
 - pull requests required before merge
 - required status checks enabled
 - the required hosted checks listed above
-- stale approvals dismissed when new commits are pushed, if practical
-- admins included only if Jess wants the fork to prevent accidental manual
-  bypasses
+- stale approvals dismissed when new commits are pushed
+- `required_approving_review_count` set to `0`
+- force-pushes and branch deletion disabled
+
+Admins are not currently included in enforcement. Do not use that bypass for
+normal PR flow.
 
 Leave self-hosted proof lanes advisory until `TIN-184` has repeated green runs
 and runner availability is no longer the dominant failure mode.

--- a/docs/program-status.md
+++ b/docs/program-status.md
@@ -36,8 +36,8 @@ As of 2026-04-25:
   proof is still uneven across the distro matrix
 - CI runtime hygiene is medium: the Linux branch is green, but GitHub Actions
   runtime upkeep still needs steady attention as hosted actions deprecate older
-  Node versions, and `main` branch protection still needs to be enforced after
-  the required check set is finalized
+  Node versions; `main` branch protection now enforces the hosted required
+  check set in `docs/ci-governance.md`
 
 ## Current Critical Path
 
@@ -174,9 +174,10 @@ explicitly reclassified before promoting more candidate tests.
 `docs/ci-governance.md` defines the required hosted checks and advisory
 self-hosted lanes for `Jesssullivan/cmux`.
 
-Current gap:
+Current rule:
 
-- `main` branch protection/rulesets still need to be enabled in GitHub
+- `main` branch protection requires PRs and the hosted CI check set before
+  normal merges
 - self-hosted KVM package-install proof remains advisory until `honey-cmux`
   availability is stable enough to act as a normal merge gate
 
@@ -245,7 +246,6 @@ repo hygiene:
    triggers in `docs/distro-testing-readiness-plan.md` become real.
 6. Replace or isolate the remaining `mlugg/setup-zig@v2` call sites as a
    separate CI hygiene follow-up.
-7. Enable `main` branch protection with the hosted required-check set in
-   `docs/ci-governance.md`.
+7. Keep `docs/ci-governance.md` aligned with workflow check-name changes.
 8. Avoid opening new architectural lanes until the existing parity matrix is
    promoted with real validation.


### PR DESCRIPTION
## Summary

- mark `main` branch protection as active in the CI governance/status docs
- remove completed `TIN-619` from active TODOs
- keep self-hosted KVM/package proof documented as advisory

## Validation

- `git diff --check`

## Notes

- No local test suites were run per repo policy.
- Commit was created with `--no-gpg-sign` because GPG signing times out in this non-interactive session.
