### PR TITLE
[codex] Fix Linux release artifact proof gates

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -195,10 +195,13 @@ jobs:
 
       - name: Sign DEB and tarball with GPG
         env:
+          REQUIRE_LINUX_GPG: "1"
           LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.LINUX_GPG_PRIVATE_KEY_BASE64 }}
           LINUX_GPG_PASSPHRASE: ${{ secrets.LINUX_GPG_PASSPHRASE }}
           LINUX_GPG_KEY_ID: ${{ secrets.LINUX_GPG_KEY_ID }}
-        run: bash scripts/sign-linux-packages.sh
+        run: |
+          bash scripts/sign-linux-packages.sh
+          bash scripts/assert-linux-package-signatures.sh
 
       - name: Upload DEB artifact
         uses: actions/upload-artifact@v4
@@ -340,10 +343,13 @@ jobs:
 
       - name: Sign RPM with GPG
         env:
+          REQUIRE_LINUX_GPG: "1"
           LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.LINUX_GPG_PRIVATE_KEY_BASE64 }}
           LINUX_GPG_PASSPHRASE: ${{ secrets.LINUX_GPG_PASSPHRASE }}
           LINUX_GPG_KEY_ID: ${{ secrets.LINUX_GPG_KEY_ID }}
-        run: bash scripts/sign-linux-packages.sh
+        run: |
+          bash scripts/sign-linux-packages.sh
+          bash scripts/assert-linux-package-signatures.sh
 
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4
@@ -461,6 +467,7 @@ jobs:
           rpmbuild -bb \
             --define "_topdir $TOPDIR" \
             --define "_builddir $PWD" \
+            --define "_build_id_links none" \
             --buildroot "$BUILDROOT" \
             --short-circuit \
             --without webkit \
@@ -473,10 +480,13 @@ jobs:
 
       - name: Sign RPM with GPG
         env:
+          REQUIRE_LINUX_GPG: "1"
           LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.LINUX_GPG_PRIVATE_KEY_BASE64 }}
           LINUX_GPG_PASSPHRASE: ${{ secrets.LINUX_GPG_PASSPHRASE }}
           LINUX_GPG_KEY_ID: ${{ secrets.LINUX_GPG_KEY_ID }}
-        run: bash scripts/sign-linux-packages.sh
+        run: |
+          bash scripts/sign-linux-packages.sh
+          bash scripts/assert-linux-package-signatures.sh
 
       - name: Upload Rocky RPM artifact
         uses: actions/upload-artifact@v4

--- a/dist/cmux.spec
+++ b/dist/cmux.spec
@@ -104,6 +104,6 @@ install -Dm644 dist/linux/70-u2f.rules %{buildroot}%{_udevrulesdir}/70-u2f.rules
 %{_udevrulesdir}/70-u2f.rules
 
 %changelog
-* Sun Apr 06 2026 Jess Sullivan <jess@jesssullivan.dev> - 0.75.0-1
+* Mon Apr 06 2026 Jess Sullivan <jess@jesssullivan.dev> - 0.75.0-1
 - Refresh Linux package metadata for current release series
 - Expand distro package testing coverage and release packaging

--- a/docs/release/SIGNING.md
+++ b/docs/release/SIGNING.md
@@ -4,7 +4,8 @@ This document covers GPG signing for the Linux release pipeline (DEB, RPM,
 tarball). Signing is performed in CI via `scripts/sign-linux-packages.sh`,
 gated on three GitHub Actions secrets in the `Jesssullivan/cmux` repo. If
 the secrets are absent the script no-ops, so local/unsigned builds keep
-working.
+working. Release CI sets `REQUIRE_LINUX_GPG=1`, so missing signing secrets
+fail the workflow instead of uploading unsigned artifacts.
 
 For end-user install and verification commands, see
 `docs/release/linux-install.md`.
@@ -28,12 +29,14 @@ audit scripts).
 build-deb (matrix: amd64 + arm64)
   └─ assemble .deb + .tar.gz
   └─ Sign DEB and tarball with GPG  ← scripts/sign-linux-packages.sh
+  └─ assert detached signatures     ← scripts/assert-linux-package-signatures.sh
   └─ upload-artifact: *.deb + *.deb.asc
   └─ upload-artifact: *.tar.gz + *.tar.gz.asc
 
 build-rpm (matrix: amd64 + arm64)
   └─ assemble .rpm
   └─ Sign RPM with GPG              ← scripts/sign-linux-packages.sh
+  └─ assert detached signatures     ← scripts/assert-linux-package-signatures.sh
   └─ upload-artifact: *.rpm + *.rpm.asc
 
 release
@@ -53,7 +56,8 @@ The signing script is **idempotent**:
 Set these on the **`Jesssullivan/cmux`** repo (Settings → Secrets and
 variables → Actions). All three must be present for signing to run; if
 `LINUX_GPG_PRIVATE_KEY_BASE64` is missing the script exits 0 with a
-warning and the release continues unsigned.
+warning by default. Release CI sets `REQUIRE_LINUX_GPG=1`, so missing
+secrets fail the workflow before artifacts are uploaded.
 
 | Secret                            | Format                                | Notes                              |
 |-----------------------------------|---------------------------------------|------------------------------------|
@@ -137,6 +141,9 @@ vars are present, and uses an ephemeral `GNUPGHOME`:
 # No-op path (no secrets in env): exits 0 with a warning
 bash scripts/sign-linux-packages.sh /tmp/some-empty-dir
 
+# Required-signing path (used by release CI): fails if secrets are absent
+REQUIRE_LINUX_GPG=1 bash scripts/sign-linux-packages.sh /tmp/some-empty-dir
+
 # Real signing locally (e.g. against a test key in your own keyring)
 LINUX_GPG_PRIVATE_KEY_BASE64="$(gpg --export-secret-keys --armor TESTKEYID | base64 -w0)" \
 LINUX_GPG_PASSPHRASE='your-test-passphrase' \
@@ -159,9 +166,9 @@ To rotate the signing key:
 
 ## Troubleshooting
 
-- **CI logs show "LINUX_GPG_PRIVATE_KEY_BASE64 not set — skipping"**:
-  the secret is missing on this fork. Set it (see above) and re-run
-  the release workflow.
+- **CI logs show "LINUX_GPG_PRIVATE_KEY_BASE64 not set"**: the secret is
+  missing on this fork. Release CI should fail loudly; set it (see above)
+  and re-run the release workflow.
 - **rpmsign quoting issues with passphrase**: the script reads the
   passphrase via `--passphrase-file` (file lives inside the ephemeral
   `GNUPGHOME`), so passphrase contents are not subject to shell quoting
@@ -173,5 +180,5 @@ To rotate the signing key:
   `gpg --list-secret-keys --keyid-format=long`.
 - **Detached `.asc` missing from release**: check the matrix-leg
   artifact (`cmux-linux-deb-amd64`, etc.) actually contains the
-  `.asc`. The `if-no-files-found: error` upload setting should fail
-  the job loudly if it doesn't.
+  `.asc`. `scripts/assert-linux-package-signatures.sh` should fail the
+  job before upload if any package lacks a detached signature.

--- a/scripts/assert-linux-package-signatures.sh
+++ b/scripts/assert-linux-package-signatures.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Verify every Linux release package in a directory has a detached signature.
+
+set -euo pipefail
+
+ARTIFACT_DIR="${1:-.}"
+
+if [ ! -d "$ARTIFACT_DIR" ]; then
+  echo "assert-linux-package-signatures: ERROR — artifact dir not found: $ARTIFACT_DIR" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+
+checked_count=0
+missing_count=0
+
+for artifact in "$ARTIFACT_DIR"/*.deb "$ARTIFACT_DIR"/*.rpm "$ARTIFACT_DIR"/*.tar.gz; do
+  checked_count=$((checked_count + 1))
+  signature="${artifact}.asc"
+  if [ ! -s "$signature" ]; then
+    echo "assert-linux-package-signatures: ERROR — missing detached signature for $artifact" >&2
+    missing_count=$((missing_count + 1))
+  fi
+done
+
+if [ "$checked_count" -eq 0 ]; then
+  echo "assert-linux-package-signatures: ERROR — no Linux package artifacts found in $ARTIFACT_DIR" >&2
+  exit 1
+fi
+
+if [ "$missing_count" -ne 0 ]; then
+  exit 1
+fi
+
+echo "assert-linux-package-signatures: verified detached signatures for $checked_count artifact(s) in $ARTIFACT_DIR"

--- a/scripts/sign-linux-packages.sh
+++ b/scripts/sign-linux-packages.sh
@@ -8,7 +8,8 @@
 #   LINUX_GPG_KEY_ID               key fingerprint or short ID (used as default-key)
 #
 # If LINUX_GPG_PRIVATE_KEY_BASE64 is empty or unset, the script no-ops with a
-# warning so that local builds (without secrets) continue to work.
+# warning so that local builds (without secrets) continue to work. Set
+# REQUIRE_LINUX_GPG=1 in release CI to fail instead.
 #
 # Signs every matching artifact in $1 (default: current directory):
 #   *.deb     → detached *.asc next to the file
@@ -24,8 +25,13 @@
 set -euo pipefail
 
 ARTIFACT_DIR="${1:-.}"
+REQUIRE_LINUX_GPG="${REQUIRE_LINUX_GPG:-0}"
 
 if [ -z "${LINUX_GPG_PRIVATE_KEY_BASE64:-}" ]; then
+  if [ "$REQUIRE_LINUX_GPG" = "1" ]; then
+    echo "sign-linux-packages: ERROR — LINUX_GPG_PRIVATE_KEY_BASE64 not set and REQUIRE_LINUX_GPG=1" >&2
+    exit 1
+  fi
   echo "sign-linux-packages: LINUX_GPG_PRIVATE_KEY_BASE64 not set — skipping (no-op for local/unsigned builds)"
   exit 0
 fi


### PR DESCRIPTION
## What changed

- Require Linux GPG signing secrets in `release-linux.yml` so release/artifact-proof runs fail loudly instead of uploading unsigned packages.
- Add `scripts/assert-linux-package-signatures.sh` and run it after signing so missing `.asc` siblings are caught before `upload-artifact`.
- Disable Rocky 10 RPM build-id link generation for the terminal-first prebuilt Zig/libghostty package path.
- Refresh the Linux signing runbook and fix the RPM changelog weekday warning.

## Why

The current artifact-proof run showed that missing signing secrets let the sign step no-op while artifact upload still succeeded with only the package file. Rocky 10 also failed RPM assembly with missing build-id link errors for the prebuilt Zig/libghostty binaries.

## Validation

- `bash -n scripts/sign-linux-packages.sh`
- `bash -n scripts/assert-linux-package-signatures.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml"); puts "yaml ok"'`
- `git diff --check`

No local package/test suites were run; this repo routes those through GitHub Actions/VMs.
