### PR TITLE
[codex] Fix Rocky RPM debugsource packaging

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -468,6 +468,8 @@ jobs:
             --define "_topdir $TOPDIR" \
             --define "_builddir $PWD" \
             --define "_build_id_links none" \
+            --define "debug_package %{nil}" \
+            --define "_enable_debug_packages 0" \
             --buildroot "$BUILDROOT" \
             --short-circuit \
             --without webkit \


### PR DESCRIPTION
## Summary

Fix Rocky 10 RPM assembly for the terminal-first package path by disabling RPM debug package generation when building from the pre-populated Zig/libghostty buildroot.

## Why

The fresh artifact-proof run after PR #253 got past the previous build-id failure, but Rocky 10 failed during RPM assembly with:

`Could not open %files file .../debugsourcefiles.list`

That file is not produced in this short-circuit packaging path because the binaries are already built by Zig before `rpmbuild` packages the buildroot.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml"); puts "yaml ok"'`
- `git diff --check`

No local package/test suite was run; repo policy keeps those in GitHub Actions/VMs.
