### PR TITLE
[codex] Skip Rocky RPM clean in short-circuit builds

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -470,6 +470,7 @@ jobs:
             --define "_build_id_links none" \
             --define "debug_package %{nil}" \
             --define "_enable_debug_packages 0" \
+            --noclean \
             --buildroot "$BUILDROOT" \
             --short-circuit \
             --without webkit \


### PR DESCRIPTION
## Summary

Skip Rocky 10 RPM `%clean` during the terminal-first short-circuit package build.

## Why

The proof run after PR #254 showed Rocky now writes the RPM successfully, but `rpmbuild` still exits nonzero during `%clean` because the short-circuit path skips `%prep`/`%autosetup`, so the expected `cmux-<version>` build subdir does not exist.

This path packages a pre-populated buildroot from already-built Zig/libghostty outputs, so skipping `%clean` is the narrow fix for this workflow-only assembly mode.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml"); puts "yaml ok"'`
- `git diff --check`

No local package/test suite was run; repo policy keeps those in GitHub Actions/VMs.
