### PR TITLE
[codex] Fix honey self-hosted workflow labels

### DIFF
--- a/.github/workflows/test-cjk.yml
+++ b/.github/workflows/test-cjk.yml
@@ -24,8 +24,8 @@ concurrency:
 
 jobs:
   cjk-input:
-    name: CJK input validation (cmux-nix)
-    runs-on: cmux-nix
+    name: CJK input validation (honey)
+    runs-on: [self-hosted, linux, gpu, cmux-test]
     environment: gpu-tests
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -27,8 +27,8 @@ concurrency:
 
 jobs:
   gpu-smoke:
-    name: GPU smoke test (cmux-nix)
-    runs-on: cmux-nix
+    name: GPU smoke test (honey)
+    runs-on: [self-hosted, linux, gpu, cmux-test]
     # Require approval via GitHub Environment protection rules.
     environment: gpu-tests
     timeout-minutes: 30

--- a/.github/workflows/test-socket.yml
+++ b/.github/workflows/test-socket.yml
@@ -27,8 +27,8 @@ concurrency:
 
 jobs:
   socket-tests:
-    name: Socket tests (cmux-nix)
-    runs-on: cmux-nix
+    name: Socket tests (honey)
+    runs-on: [self-hosted, linux, gpu, cmux-test]
     environment: gpu-tests
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## What changed

- Move socket, GPU smoke, and CJK self-hosted workflows off the stale `cmux-nix` runner label.
- Target the currently registered honey runner labels: `self-hosted`, `linux`, `gpu`, `cmux-test`.

## Why

`Jesssullivan/cmux` currently has one registered repo runner, `honey-cmux`, with labels `self-hosted,Linux,X64,gpu,cmux-test,kvm,cmux-distro-test`. It does not advertise `cmux-nix`, so manual self-hosted jobs can queue without ever assigning a runner.

The stale queued socket run `24949176068` was cancelled separately.

## Validation

- `git diff --check`
- Parsed edited workflow YAML files with Ruby/Psych

Note: `honey-cmux` is still offline, so this removes the label mismatch but does not restore machine availability.
