### PR TITLE
[codex] Remove external setup action from self-hosted tests

### DIFF
--- a/.github/workflows/test-cjk.yml
+++ b/.github/workflows/test-cjk.yml
@@ -34,8 +34,13 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
-      - name: Setup GloriousFlywheel
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+      - name: Add Nix to PATH
+        run: |
+          for nixbin in /nix/var/nix/profiles/default/bin "$HOME/.nix-profile/bin"; do
+            if [ -d "$nixbin" ]; then
+              echo "$nixbin" >> "$GITHUB_PATH"
+            fi
+          done
 
       - name: Configure self-hosted Nix
         run: bash scripts/configure-self-hosted-nix.sh

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -38,8 +38,13 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
-      - name: Setup GloriousFlywheel
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+      - name: Add Nix to PATH
+        run: |
+          for nixbin in /nix/var/nix/profiles/default/bin "$HOME/.nix-profile/bin"; do
+            if [ -d "$nixbin" ]; then
+              echo "$nixbin" >> "$GITHUB_PATH"
+            fi
+          done
 
       - name: Configure self-hosted Nix
         run: bash scripts/configure-self-hosted-nix.sh

--- a/.github/workflows/test-socket.yml
+++ b/.github/workflows/test-socket.yml
@@ -37,8 +37,13 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
-      - name: Setup GloriousFlywheel
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+      - name: Add Nix to PATH
+        run: |
+          for nixbin in /nix/var/nix/profiles/default/bin "$HOME/.nix-profile/bin"; do
+            if [ -d "$nixbin" ]; then
+              echo "$nixbin" >> "$GITHUB_PATH"
+            fi
+          done
 
       - name: Configure self-hosted Nix
         run: bash scripts/configure-self-hosted-nix.sh


### PR DESCRIPTION
## Summary
- replace the private GloriousFlywheel setup action in self-hosted socket/CJK/GPU workflows with a local Nix PATH bootstrap
- keep the existing `scripts/configure-self-hosted-nix.sh` runner contract as the authoritative setup step

## Why
- `test-socket.yml` failed during Actions setup with `Unable to resolve action tinyland-inc/gloriousflywheel, not found` before checkout
- the local GloriousFlywheel action only added Nix profile paths and cache hints; these workflows only need the Nix path bootstrap before running the cmux-owned script

## Validation
- `git diff --check -- .github/workflows/test-socket.yml .github/workflows/test-cjk.yml .github/workflows/test-gpu.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/test-socket.yml .github/workflows/test-cjk.yml .github/workflows/test-gpu.yml`\n