### PR TITLE
Skip RPM build deps for prebuilt release payloads

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -336,6 +336,7 @@ jobs:
           rpmbuild -bb \
             --define "_topdir $TOPDIR" \
             --define "_builddir $PWD" \
+            --nodeps \
             --with prebuilt \
             "$TOPDIR/SPECS/cmux.spec"
 
@@ -478,6 +479,7 @@ jobs:
             --define "debug_package %{nil}" \
             --define "_enable_debug_packages 0" \
             --noclean \
+            --nodeps \
             --with prebuilt \
             --without webkit \
             "$TOPDIR/SPECS/cmux.spec"


### PR DESCRIPTION
## Summary
- add `rpmbuild --nodeps` to the release workflow's prebuilt RPM assembly path
- keep normal spec/source builds unchanged, including `BuildRequires`

## Why
The first fresh Linux release proof run after #264 reached RPM assembly, then Fedora and Rocky RPM legs failed before signing because `rpmbuild -bb --with prebuilt` still enforced `BuildRequires: zig >= 0.15.2`. The release workflow has already built the payload with a manually installed Zig, so the prebuilt RPM packaging step should not try to resolve build dependencies from distro RPM repos.

Failed proof run: https://github.com/Jesssullivan/cmux/actions/runs/25058267208

## Validation
- `git diff --check`
- inspected release workflow `rpmbuild` invocations to confirm `--nodeps` is scoped only to `--with prebuilt` RPM package assembly
