### PR TITLE
Fix Linux package RUNPATHs

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -65,7 +65,7 @@ jobs:
             libwebkitgtk-6.0-dev \
             libfreetype-dev libharfbuzz-dev libfontconfig-dev \
             libpng-dev libonig-dev libgl-dev \
-            glslang-tools spirv-cross
+            glslang-tools spirv-cross patchelf
 
       - name: Build vendor libraries
         run: |
@@ -129,6 +129,7 @@ jobs:
           # Binary + shared library
           install -Dm755 cmux-linux/zig-out/bin/cmux "${PKG}/usr/bin/cmux"
           install -Dm755 ghostty/zig-out/lib/libghostty.so "${PKG}/usr/lib/cmux/libghostty.so"
+          bash scripts/set-linux-package-rpath.sh "${PKG}/usr/bin/cmux" "/usr/lib/cmux"
 
           # cmuxd
           if [ -f cmuxd/zig-out/bin/cmuxd ]; then
@@ -157,10 +158,11 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           STAGING="cmux-${VERSION}-linux-${TAR_ARCH}"
-          mkdir -p "${STAGING}"/{bin,lib,share/{applications,metainfo,icons/hicolor/{16x16,128x128,256x256,512x512}/apps},lib/udev/rules.d}
+          mkdir -p "${STAGING}"/{bin,lib/cmux,share/{applications,metainfo,icons/hicolor/{16x16,128x128,256x256,512x512}/apps},lib/udev/rules.d}
 
           cp cmux-linux/zig-out/bin/cmux "${STAGING}/bin/"
-          cp ghostty/zig-out/lib/libghostty.so "${STAGING}/lib/"
+          cp ghostty/zig-out/lib/libghostty.so "${STAGING}/lib/cmux/"
+          bash scripts/set-linux-package-rpath.sh "${STAGING}/bin/cmux" '$ORIGIN/../lib/cmux'
           if [ -f cmuxd/zig-out/bin/cmuxd ]; then
             cp cmuxd/zig-out/bin/cmuxd "${STAGING}/bin/"
           fi
@@ -177,7 +179,7 @@ jobs:
           set -e
           PREFIX="${1:-/usr/local}"
           install -Dm755 bin/cmux "$PREFIX/bin/cmux"
-          install -Dm755 lib/libghostty.so "$PREFIX/lib/cmux/libghostty.so"
+          install -Dm755 lib/cmux/libghostty.so "$PREFIX/lib/cmux/libghostty.so"
           [ -f bin/cmuxd ] && install -Dm755 bin/cmuxd "$PREFIX/bin/cmuxd"
           install -Dm644 share/applications/com.jesssullivan.cmux.desktop "$PREFIX/share/applications/com.jesssullivan.cmux.desktop"
           install -Dm644 share/metainfo/com.jesssullivan.cmux.metainfo.xml "$PREFIX/share/metainfo/com.jesssullivan.cmux.metainfo.xml"
@@ -244,7 +246,8 @@ jobs:
             libsecret-devel libnotify-devel \
             wayland-devel wayland-protocols-devel \
             freetype-devel harfbuzz-devel fontconfig-devel \
-            libpng-devel oniguruma-devel mesa-libGL-devel
+            libpng-devel oniguruma-devel mesa-libGL-devel \
+            patchelf
 
       - uses: actions/checkout@v5
         with:
@@ -311,6 +314,7 @@ jobs:
           # Install files into buildroot (must match %files in spec)
           install -Dm755 cmux-linux/zig-out/bin/cmux "${BUILDROOT}/usr/bin/cmux"
           install -Dm755 ghostty/zig-out/lib/libghostty.so "${BUILDROOT}${LIBDIR}/cmux/libghostty.so"
+          bash scripts/set-linux-package-rpath.sh "${BUILDROOT}/usr/bin/cmux" "${LIBDIR}/cmux"
           if [ -f cmuxd/zig-out/bin/cmuxd ]; then
             install -Dm755 cmuxd/zig-out/bin/cmuxd "${BUILDROOT}/usr/bin/cmuxd"
           fi
@@ -389,7 +393,8 @@ jobs:
             wayland-devel wayland-protocols-devel \
             freetype-devel harfbuzz-devel fontconfig-devel \
             libpng-devel oniguruma-devel mesa-libGL-devel \
-            glslang
+            glslang \
+            patchelf
 
       - uses: actions/checkout@v5
         with:
@@ -453,6 +458,7 @@ jobs:
 
           install -Dm755 cmux-linux/zig-out/bin/cmux "${BUILDROOT}/usr/bin/cmux"
           install -Dm755 ghostty/zig-out/lib/libghostty.so "${BUILDROOT}${LIBDIR}/cmux/libghostty.so"
+          bash scripts/set-linux-package-rpath.sh "${BUILDROOT}/usr/bin/cmux" "${LIBDIR}/cmux"
           if [ -f cmuxd/zig-out/bin/cmuxd ]; then
             install -Dm755 cmuxd/zig-out/bin/cmuxd "${BUILDROOT}/usr/bin/cmuxd"
           fi

--- a/dist/cmux.spec
+++ b/dist/cmux.spec
@@ -14,6 +14,7 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  zig >= 0.15.2
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
+BuildRequires:  patchelf
 BuildRequires:  pkg-config
 BuildRequires:  gtk4-devel >= 4.10
 BuildRequires:  libadwaita-devel >= 1.3
@@ -94,6 +95,8 @@ install -Dm644 dist/linux/70-u2f.rules %{buildroot}%{_udevrulesdir}/70-u2f.rules
 install -Dm644 LICENSE %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
 install -Dm644 README.md %{buildroot}%{_datadir}/doc/%{name}/README.md
 %endif
+
+patchelf --set-rpath %{_libdir}/cmux %{buildroot}%{_bindir}/cmux
 
 %post
 /usr/bin/gtk-update-icon-cache -q %{_datadir}/icons/hicolor 2>/dev/null || :

--- a/packaging/copr/cmux.spec
+++ b/packaging/copr/cmux.spec
@@ -17,6 +17,7 @@ BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  git
 BuildRequires:  glslang
+BuildRequires:  patchelf
 BuildRequires:  pkg-config
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  zig >= 0.15.2
@@ -89,6 +90,7 @@ done
 install -Dm644 dist/linux/70-u2f.rules %{buildroot}%{_udevrulesdir}/70-u2f.rules
 install -Dm644 LICENSE %{buildroot}%{_licensedir}/%{name}/LICENSE
 install -Dm644 README.md %{buildroot}%{_docdir}/%{name}/README.md
+patchelf --set-rpath %{_libdir}/cmux %{buildroot}%{_bindir}/cmux
 
 %post
 /usr/bin/gtk-update-icon-cache -q %{_datadir}/icons/hicolor 2>/dev/null || :

--- a/scripts/set-linux-package-rpath.sh
+++ b/scripts/set-linux-package-rpath.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <binary> <rpath>" >&2
+  exit 2
+fi
+
+binary="$1"
+rpath="$2"
+
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "error: patchelf is required to set the packaged cmux RUNPATH" >&2
+  exit 1
+fi
+
+if [ ! -f "$binary" ]; then
+  echo "error: binary not found: $binary" >&2
+  exit 1
+fi
+
+patchelf --set-rpath "$rpath" "$binary"
+
+actual="$(patchelf --print-rpath "$binary")"
+if [ "$actual" != "$rpath" ]; then
+  echo "error: expected RUNPATH '$rpath', got '$actual'" >&2
+  exit 1
+fi
+
+case "$actual" in
+  *ghostty/zig-out/lib*)
+    echo "error: packaged cmux binary still references build-tree libghostty path: $actual" >&2
+    exit 1
+    ;;
+esac
+
+echo "set RUNPATH on $binary: $actual"


### PR DESCRIPTION
## Summary
- set packaged cmux RUNPATHs to the installed libghostty locations for DEB, RPM, and generic tarball artifacts
- add a small packaging helper that fails if the build-tree ghostty runpath remains
- teach the release and COPR RPM specs to use patchelf for source/prebuilt RPM builds

## Validation
- bash -n scripts/set-linux-package-rpath.sh
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml")'
- nix shell nixpkgs#rpm --command rpmspec -P dist/cmux.spec
- nix shell nixpkgs#rpm --command rpmspec -P --with prebuilt dist/cmux.spec
- nix shell nixpkgs#rpm --command rpmspec -P packaging/copr/cmux.spec

## Notes
This addresses the RPM assembly failure in Linux Release run 25059840787 where Fedora/Rocky rejected /usr/bin/cmux for carrying the development RUNPATH ../ghostty/zig-out/lib.