### PR TITLE
Enable EPEL for Rocky release patchelf

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -383,7 +383,7 @@ jobs:
     steps:
       - name: Install build dependencies
         run: |
-          dnf install -y dnf-plugins-core
+          dnf install -y dnf-plugins-core epel-release
           dnf config-manager --set-enabled crb
           dnf install -y \
             git rpm-build rpm-sign gnupg2 systemd-rpm-macros \

--- a/scripts/sign-linux-packages.sh
+++ b/scripts/sign-linux-packages.sh
@@ -88,6 +88,11 @@ if ! gpg --list-secret-keys "$LINUX_GPG_KEY_ID" >/dev/null 2>&1; then
   exit 1
 fi
 
+PUBLIC_KEY_FILE="$GNUPGHOME/public.asc"
+gpg --batch --armor --export "$LINUX_GPG_KEY_ID" > "$PUBLIC_KEY_FILE"
+RPM_DBPATH="$GNUPGHOME/rpmdb"
+mkdir -p "$RPM_DBPATH"
+
 # Write the passphrase to a file inside the ephemeral GNUPGHOME so it
 # gets cleaned up by `trap cleanup EXIT`. Using --passphrase-file avoids
 # embedding shell-specific syntax (here-strings) in %__gpg_sign_cmd —
@@ -134,8 +139,13 @@ sign_rpm() {
   rpmsign --addsign "$file"
   # Verify the in-package signature was actually applied.
   echo "sign-linux-packages: verifying in-package RPM signature for $file"
-  rpm -K "$file" 2>&1 | sed 's/^/  rpm: /'
-  if ! rpm -K "$file" | grep -q 'signatures OK'; then
+  if command -v rpmkeys >/dev/null 2>&1; then
+    rpmkeys --dbpath "$RPM_DBPATH" --import "$PUBLIC_KEY_FILE"
+  else
+    rpm --dbpath "$RPM_DBPATH" --import "$PUBLIC_KEY_FILE"
+  fi
+  rpm --dbpath "$RPM_DBPATH" -K "$file" 2>&1 | sed 's/^/  rpm: /'
+  if ! rpm --dbpath "$RPM_DBPATH" -K "$file" | grep -q 'signatures OK'; then
     echo "sign-linux-packages: ERROR — RPM signature verification failed for $file" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- install epel-release in the Rocky 10 Linux Release build container before installing patchelf
- keep EPEL scoped to the build container so the produced RPM runtime dependency surface does not change

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml")'

## Notes
Linux Release run 25061983433 confirmed Fedora/DEB continued past dependency install, but both Rocky 10 RPM jobs failed immediately because Rocky BaseOS/AppStream/CRB did not provide patchelf.