### PR TITLE
[codex] Retry libghostty builds in Linux release

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -142,9 +142,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
           echo "libghostty.a: $(ls -lh ghostty/zig-out/lib/libghostty.a)"
           echo "ghostty.h: $(ls -lh ghostty/zig-out/include/ghostty.h)"
@@ -354,9 +355,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (Debian 12 baseline)
@@ -454,9 +456,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (Ubuntu 24.04)
@@ -553,9 +556,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (Fedora)
@@ -631,9 +635,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (Arch)
@@ -715,9 +720,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (Rocky 10)

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -76,9 +76,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux
@@ -280,9 +281,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux
@@ -427,9 +429,10 @@ jobs:
 
       - name: Build libghostty
         run: |
-          cd ghostty
-          zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
-          cd ..
+          bash scripts/retry-zig-build.sh \
+            --label "libghostty" \
+            --working-directory ghostty \
+            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (terminal-first)

--- a/scripts/retry-zig-build.sh
+++ b/scripts/retry-zig-build.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: retry-zig-build.sh [--label NAME] [--working-directory DIR] -- COMMAND [ARGS...]
+
+Retries a Zig build command after clearing Zig's package cache. This is intended
+for CI legs that fetch upstream Zig packages and can fail on transient archive
+download or unpack errors.
+USAGE
+}
+
+label="zig build"
+workdir=""
+attempts="${ZIG_BUILD_RETRIES:-3}"
+delay_seconds="${ZIG_BUILD_RETRY_DELAY_SECONDS:-15}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label)
+      label="${2:?missing value for --label}"
+      shift 2
+      ;;
+    --working-directory)
+      workdir="${2:?missing value for --working-directory}"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "error: missing command" >&2
+  usage
+  exit 2
+fi
+
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [[ "$attempts" -lt 1 ]]; then
+  echo "error: ZIG_BUILD_RETRIES must be a positive integer" >&2
+  exit 2
+fi
+
+if ! [[ "$delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "error: ZIG_BUILD_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+if [[ -n "$workdir" ]]; then
+  cd "$workdir"
+fi
+
+attempt=1
+while true; do
+  echo "==> ${label}: attempt ${attempt}/${attempts}"
+  if "$@"; then
+    exit 0
+  fi
+
+  status=$?
+  if [[ "$attempt" -ge "$attempts" ]]; then
+    echo "error: ${label} failed after ${attempts} attempts" >&2
+    exit "$status"
+  fi
+
+  cache_dir="${ZIG_GLOBAL_CACHE_DIR:-$HOME/.cache/zig}"
+  if [[ -d "$cache_dir" ]]; then
+    echo "warning: ${label} failed with exit ${status}; clearing Zig package cache before retry" >&2
+    rm -rf "$cache_dir/p" "$cache_dir/tmp"
+  else
+    echo "warning: ${label} failed with exit ${status}; retrying" >&2
+  fi
+
+  if [[ "$delay_seconds" -gt 0 ]]; then
+    sleep "$delay_seconds"
+  fi
+  attempt=$((attempt + 1))
+done


### PR DESCRIPTION
## Summary

Adds a narrow retry wrapper for the Linux release `libghostty` build step and uses it in the DEB, Fedora RPM, and Rocky RPM package jobs.

## Why

The `lab-v0.75.0` release proof run hit a transient Zig package fetch/unpack failure while building Ghostty's `highway` dependency:

- run: https://github.com/Jesssullivan/cmux/actions/runs/25063590877
- failing step: `Build DEB package (Ubuntu, amd64)` / `Build libghostty`
- error: `unable to unpack tarball to temporary directory: ReadFailed`

We have also seen transient dependency-fetch failures in earlier release proof attempts, so retrying this build boundary should reduce wasted full-matrix release runs without changing package assembly or signing behavior.

## Validation

- `bash -n scripts/retry-zig-build.sh`
- `git diff --check`
