### PR TITLE
[codex] Retry package manager operations in distro VM checks

### DIFF
--- a/nix/tests-distro.nix
+++ b/nix/tests-distro.nix
@@ -157,6 +157,23 @@
     vm.succeed("ip route show && cat /etc/resolv.conf")
   '';
 
+  packageManagerSucceed = command: ''
+    vm.succeed("""
+      status=0
+      for attempt in 1 2 3; do
+        if ${command}; then
+          exit 0
+        fi
+        status=$?
+        echo "attempt $attempt/3 failed for ${lib.escapeShellArg command} (exit $status)" >&2
+        if [ "$attempt" -lt 3 ]; then
+          sleep 20
+        fi
+      done
+      exit "$status"
+    """)
+  '';
+
   distro-fedora42 =
     (nvt.fedora."42" {
       sharedDirs = {
@@ -168,8 +185,8 @@
       testScript = ''
         vm.wait_for_unit("multi-user.target")
 
-        vm.succeed("timeout 300 dnf makecache")
-        vm.succeed("timeout 300 dnf install -y /mnt/pkg/*")
+        ${packageManagerSucceed "timeout 300 dnf makecache"}
+        ${packageManagerSucceed "timeout 300 dnf install -y /mnt/pkg/*"}
 
         # Verify binary is installed
         vm.succeed("test -f /usr/bin/cmux")
@@ -184,12 +201,12 @@
 
         ${rockyNetworkBootstrap}
 
-        vm.succeed("timeout 300 dnf install -y dnf-plugins-core")
+        ${packageManagerSucceed "timeout 300 dnf install -y dnf-plugins-core"}
         vm.succeed("dnf config-manager --set-enabled crb")
-        vm.succeed("timeout 300 dnf makecache")
+        ${packageManagerSucceed "timeout 300 dnf makecache"}
 
         # Install the constrained Rocky 10 RPM
-        vm.succeed("timeout 300 dnf install -y /opt/*.rpm")
+        ${packageManagerSucceed "timeout 300 dnf install -y /opt/*.rpm"}
 
         # Verify binary is installed
         vm.succeed("test -f /usr/bin/cmux")
@@ -205,11 +222,11 @@
         ${rockyNetworkBootstrap}
 
         # Enable EPEL for GTK4/libadwaita on Rocky 9
-        vm.succeed("timeout 300 dnf install -y epel-release")
-        vm.succeed("timeout 300 dnf makecache")
+        ${packageManagerSucceed "timeout 300 dnf install -y epel-release"}
+        ${packageManagerSucceed "timeout 300 dnf makecache"}
 
         # Install the RPM
-        vm.succeed("rpm -ivh /opt/*.rpm || timeout 300 dnf install -y /opt/*.rpm")
+        ${packageManagerSucceed "rpm -ivh /opt/*.rpm || timeout 300 dnf install -y /opt/*.rpm"}
 
         # Verify binary is installed
         vm.succeed("test -f /usr/bin/cmux")
@@ -229,10 +246,10 @@
       testScript = ''
         vm.wait_for_unit("multi-user.target")
 
-        vm.succeed("timeout 300 apt-get update")
+        ${packageManagerSucceed "timeout 300 apt-get update"}
 
         # Install the DEB and resolve dependencies
-        vm.succeed("dpkg -i /mnt/pkg/* || timeout 300 apt-get install -f -y")
+        ${packageManagerSucceed "dpkg -i /mnt/pkg/* || timeout 300 apt-get install -f -y"}
 
         # Verify binary is installed
         vm.succeed("test -f /usr/bin/cmux")
@@ -253,10 +270,10 @@
       testScript = ''
         vm.wait_for_unit("multi-user.target")
 
-        vm.succeed("timeout 300 apt-get update")
+        ${packageManagerSucceed "timeout 300 apt-get update"}
 
         # Install the DEB and resolve dependencies
-        vm.succeed("dpkg -i /mnt/pkg/* || timeout 300 apt-get install -f -y")
+        ${packageManagerSucceed "dpkg -i /mnt/pkg/* || timeout 300 apt-get install -f -y"}
 
         # Verify binary is installed
         vm.succeed("test -f /usr/bin/cmux")


### PR DESCRIPTION
## Summary

Adds a bounded retry wrapper for package-manager operations inside the non-NixOS distro VM package checks.

## Why

The `lab-v0.75.0` Linux release proof has all six package build/signing legs green, but distro validation failed in the Rocky 10 VM while fetching repository metadata:

- run: https://github.com/Jesssullivan/cmux/actions/runs/25067458251
- failing step: `Rocky 10 package test`
- failing command: `timeout 300 dnf install -y dnf-plugins-core`
- error: Rocky `baseos` metadata/mirror download failure before installing the cmux RPM

This is a transient repository/network failure in the VM, not an artifact failure. The actual artifact checks remain strict.

## Validation

- `nix-instantiate --parse nix/tests-distro.nix`
- `git diff --check`
