### PR TITLE
[codex] Fix Rocky 10 distro VM repository bootstrap

### DIFF
--- a/nix/tests-distro.nix
+++ b/nix/tests-distro.nix
@@ -155,16 +155,29 @@
     # resolver config. 10.0.2.3 is QEMU's built-in DNS endpoint.
     vm.succeed("printf 'nameserver 10.0.2.3\\noptions timeout:1 attempts:3\\n' > /etc/resolv.conf")
     vm.succeed("ip route show && cat /etc/resolv.conf")
+    vm.succeed("""
+      . /etc/os-release
+      if [ "''${VERSION_ID:-}" = "10.1" ]; then
+        for repo in /etc/yum.repos.d/*.repo; do
+          [ -f "$repo" ] || continue
+          sed -i -E 's|(https?://(dl|download)\\.rockylinux\\.org)/vault/rocky/|\\1/pub/rocky/|g' "$repo"
+        done
+        dnf clean all
+        grep -R "rocky/.*/BaseOS" /etc/yum.repos.d || true
+      fi
+    """)
   '';
 
   packageManagerSucceed = command: ''
     vm.succeed("""
+      set +e
       status=0
       for attempt in 1 2 3; do
-        if ${command}; then
+        ${command}
+        status=$?
+        if [ "$status" -eq 0 ]; then
           exit 0
         fi
-        status=$?
         echo "attempt $attempt/3 failed for ${lib.escapeShellArg command} (exit $status)" >&2
         if [ "$attempt" -lt 3 ]; then
           sleep 20


### PR DESCRIPTION
## Summary

Fixes the Rocky 10 distro VM package check after the `lab-v0.75.0` release proof exposed a stale repository URL in the Rocky 10.1 image.

## Why

Release run `25079806885` got all six package build/signing legs green, then failed in `Rocky 10 package test`:

- run: https://github.com/Jesssullivan/cmux/actions/runs/25079806885
- failing step: `Rocky 10 package test`
- failing repo URL: `http://dl.rockylinux.org/vault/rocky/10.1/BaseOS/x86_64/os/repodata/repomd.xml`
- error: `404`, so retries cannot fix it by themselves

Current URL check from the runner host:

- `https://dl.rockylinux.org/vault/rocky/10.1/BaseOS/x86_64/os/repodata/repomd.xml` -> 404
- `https://dl.rockylinux.org/pub/rocky/10.1/BaseOS/x86_64/os/repodata/repomd.xml` -> 200

## Changes

- Rewrites Rocky 10.1 VM repo files from the stale `vault/rocky/` tree to the current `pub/rocky/` tree during Rocky network bootstrap.
- Keeps the rewrite scoped to `VERSION_ID=10.1`, so Rocky 9.5 continues to use its valid vault path.
- Fixes the package-manager retry helper so it preserves failed command exit codes instead of losing them after `if ... fi`.

## Validation

- `nix-instantiate --parse nix/tests-distro.nix`
- `git diff --check`
