### PR TITLE
[codex] Build Linux release artifacts for generic CPU targets

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - { deb: amd64, tar: amd64, runner: ubuntu-latest }
-          - { deb: arm64, tar: arm64, runner: ubuntu-24.04-arm }
+          - { deb: amd64, tar: amd64, runner: ubuntu-latest, zig: x86_64-linux-gnu }
+          - { deb: arm64, tar: arm64, runner: ubuntu-24.04-arm, zig: aarch64-linux-gnu }
     outputs:
       # Both matrix legs compute the same value, so this is safe — GHA
       # picks an arbitrary leg's value, and downstream jobs only care that
@@ -69,28 +69,28 @@ jobs:
 
       - name: Build vendor libraries
         run: |
-          cd vendor/ctap2 && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-crypto && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-keychain && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-notify && zig build -Doptimize=ReleaseFast && cd ../..
+          cd vendor/ctap2 && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-crypto && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-keychain && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-notify && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
 
       - name: Build libghostty
         run: |
           bash scripts/retry-zig-build.sh \
             --label "libghostty" \
             --working-directory ghostty \
-            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
+            -- zig build -Dtarget=${{ matrix.arch.zig }} -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux
         run: |
           cd cmux-linux
-          zig build -Doptimize=ReleaseFast
+          zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
 
       - name: Build cmuxd
         run: |
           if [ -d cmuxd ]; then
-            cd cmuxd && zig build -Doptimize=ReleaseFast
+            cd cmuxd && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
           fi
 
       - name: Assemble DEB package
@@ -234,8 +234,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - { rpm: x86_64, runner: ubuntu-latest }
-          - { rpm: aarch64, runner: ubuntu-24.04-arm }
+          - { rpm: x86_64, runner: ubuntu-latest, zig: x86_64-linux-gnu }
+          - { rpm: aarch64, runner: ubuntu-24.04-arm, zig: aarch64-linux-gnu }
     steps:
       - name: Install build dependencies
         run: |
@@ -274,28 +274,28 @@ jobs:
 
       - name: Build vendor libraries
         run: |
-          cd vendor/ctap2 && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-crypto && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-keychain && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-notify && zig build -Doptimize=ReleaseFast && cd ../..
+          cd vendor/ctap2 && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-crypto && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-keychain && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-notify && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
 
       - name: Build libghostty
         run: |
           bash scripts/retry-zig-build.sh \
             --label "libghostty" \
             --working-directory ghostty \
-            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
+            -- zig build -Dtarget=${{ matrix.arch.zig }} -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux
         run: |
           cd cmux-linux
-          zig build -Doptimize=ReleaseFast
+          zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
 
       - name: Build cmuxd
         run: |
           if [ -d cmuxd ]; then
-            cd cmuxd && zig build -Doptimize=ReleaseFast
+            cd cmuxd && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
           fi
 
       - name: Assemble RPM package
@@ -380,8 +380,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - { rpm: x86_64, runner: ubuntu-latest }
-          - { rpm: aarch64, runner: ubuntu-24.04-arm }
+          - { rpm: x86_64, runner: ubuntu-latest, zig: x86_64-linux-gnu }
+          - { rpm: aarch64, runner: ubuntu-24.04-arm, zig: aarch64-linux-gnu }
     steps:
       - name: Install build dependencies
         run: |
@@ -422,28 +422,28 @@ jobs:
 
       - name: Build vendor libraries
         run: |
-          cd vendor/ctap2 && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-crypto && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-keychain && zig build -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-notify && zig build -Doptimize=ReleaseFast && cd ../..
+          cd vendor/ctap2 && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-crypto && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-keychain && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-notify && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
 
       - name: Build libghostty
         run: |
           bash scripts/retry-zig-build.sh \
             --label "libghostty" \
             --working-directory ghostty \
-            -- zig build -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
+            -- zig build -Dtarget=${{ matrix.arch.zig }} -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (terminal-first)
         run: |
           cd cmux-linux
-          zig build -Doptimize=ReleaseFast -Dno-webkit=true
+          zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast -Dno-webkit=true
 
       - name: Build cmuxd
         run: |
           if [ -d cmuxd ]; then
-            cd cmuxd && zig build -Doptimize=ReleaseFast
+            cd cmuxd && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
           fi
 
       - name: Assemble RPM package

--- a/nix/tests-distro.nix
+++ b/nix/tests-distro.nix
@@ -140,7 +140,7 @@
   # Used by all distro tests after package install.
   socketPingTest = ''
     # Verify binary runs
-    vm.succeed("cmux --version 2>&1 || cmux --help 2>&1 || echo 'binary runs'")
+    vm.succeed("cmux --version 2>&1 || cmux --help 2>&1")
 
     # Verify runtime library deps resolve cleanly after package install
     vm.succeed("""
@@ -160,7 +160,7 @@
       if [ "''${VERSION_ID:-}" = "10.1" ]; then
         for repo in /etc/yum.repos.d/*.repo; do
           [ -f "$repo" ] || continue
-          sed -i -E 's|(https?://(dl|download)\\.rockylinux\\.org)/vault/rocky/|\\1/pub/rocky/|g' "$repo"
+          sed -i -E 's#(https?://(dl|download)\\.rockylinux\\.org)/vault/rocky/#\\1/pub/rocky/#g' "$repo"
         done
         dnf clean all
         grep -R "rocky/.*/BaseOS" /etc/yum.repos.d || true


### PR DESCRIPTION
## Summary

Makes Linux release artifacts build for generic Linux CPU targets instead of the native runner CPU, and tightens the distro VM smoke test so crashing binaries cannot pass.

## Why

Release proof `25081237436` showed two separate problems:

- Rocky 10 repo bootstrap still had a sed delimiter bug from PR #271.
- Fedora VM validation installed the RPM but both `cmux --version` and `cmux --help` trapped with `Illegal instruction`. The current smoke test masked that with `|| echo 'binary runs'`, so validation continued instead of failing at the real runtime issue.

The illegal-instruction trace strongly points at native-runner CPU feature leakage in release builds. The release workflow was building all Zig components without `-Dtarget`, which lets Zig optimize for the native builder CPU. That is not acceptable for distro artifacts expected to run inside older or more constrained VM/user CPUs.

## Changes

- Add generic Zig target triples to each Linux release matrix:
  - `x86_64-linux-gnu`
  - `aarch64-linux-gnu`
- Pass the matrix target to release builds for vendor Zig libs, libghostty, cmux-linux, and cmuxd.
- Tighten distro VM binary smoke check to require `cmux --version` or `cmux --help` to actually succeed.
- Fix the Rocky 10.1 repo rewrite sed expression by switching to a delimiter that does not conflict with the regex alternative.

## Validation

- `nix-instantiate --parse nix/tests-distro.nix`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml"); puts "release-linux.yml parses"'`
- `git diff --check`

`actionlint` is not installed locally, so full workflow validation will come from GitHub Actions.
