### PR TITLE
[codex] Use baseline CPU for Linux release builds

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - { deb: amd64, tar: amd64, runner: ubuntu-latest, zig: x86_64-linux-gnu }
-          - { deb: arm64, tar: arm64, runner: ubuntu-24.04-arm, zig: aarch64-linux-gnu }
+          - { deb: amd64, tar: amd64, runner: ubuntu-latest }
+          - { deb: arm64, tar: arm64, runner: ubuntu-24.04-arm }
     outputs:
       # Both matrix legs compute the same value, so this is safe — GHA
       # picks an arbitrary leg's value, and downstream jobs only care that
@@ -69,28 +69,28 @@ jobs:
 
       - name: Build vendor libraries
         run: |
-          cd vendor/ctap2 && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-crypto && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-keychain && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-notify && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/ctap2 && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-crypto && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-keychain && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-notify && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
 
       - name: Build libghostty
         run: |
           bash scripts/retry-zig-build.sh \
             --label "libghostty" \
             --working-directory ghostty \
-            -- zig build -Dtarget=${{ matrix.arch.zig }} -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
+            -- zig build -Dcpu=baseline -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux
         run: |
           cd cmux-linux
-          zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
+          zig build -Dcpu=baseline -Doptimize=ReleaseFast
 
       - name: Build cmuxd
         run: |
           if [ -d cmuxd ]; then
-            cd cmuxd && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
+            cd cmuxd && zig build -Dcpu=baseline -Doptimize=ReleaseFast
           fi
 
       - name: Assemble DEB package
@@ -234,8 +234,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - { rpm: x86_64, runner: ubuntu-latest, zig: x86_64-linux-gnu }
-          - { rpm: aarch64, runner: ubuntu-24.04-arm, zig: aarch64-linux-gnu }
+          - { rpm: x86_64, runner: ubuntu-latest }
+          - { rpm: aarch64, runner: ubuntu-24.04-arm }
     steps:
       - name: Install build dependencies
         run: |
@@ -274,28 +274,28 @@ jobs:
 
       - name: Build vendor libraries
         run: |
-          cd vendor/ctap2 && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-crypto && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-keychain && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-notify && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/ctap2 && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-crypto && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-keychain && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-notify && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
 
       - name: Build libghostty
         run: |
           bash scripts/retry-zig-build.sh \
             --label "libghostty" \
             --working-directory ghostty \
-            -- zig build -Dtarget=${{ matrix.arch.zig }} -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
+            -- zig build -Dcpu=baseline -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux
         run: |
           cd cmux-linux
-          zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
+          zig build -Dcpu=baseline -Doptimize=ReleaseFast
 
       - name: Build cmuxd
         run: |
           if [ -d cmuxd ]; then
-            cd cmuxd && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
+            cd cmuxd && zig build -Dcpu=baseline -Doptimize=ReleaseFast
           fi
 
       - name: Assemble RPM package
@@ -380,8 +380,8 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - { rpm: x86_64, runner: ubuntu-latest, zig: x86_64-linux-gnu }
-          - { rpm: aarch64, runner: ubuntu-24.04-arm, zig: aarch64-linux-gnu }
+          - { rpm: x86_64, runner: ubuntu-latest }
+          - { rpm: aarch64, runner: ubuntu-24.04-arm }
     steps:
       - name: Install build dependencies
         run: |
@@ -422,28 +422,28 @@ jobs:
 
       - name: Build vendor libraries
         run: |
-          cd vendor/ctap2 && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-crypto && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-keychain && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
-          cd vendor/zig-notify && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast && cd ../..
+          cd vendor/ctap2 && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-crypto && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-keychain && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
+          cd vendor/zig-notify && zig build -Dcpu=baseline -Doptimize=ReleaseFast && cd ../..
 
       - name: Build libghostty
         run: |
           bash scripts/retry-zig-build.sh \
             --label "libghostty" \
             --working-directory ghostty \
-            -- zig build -Dtarget=${{ matrix.arch.zig }} -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
+            -- zig build -Dcpu=baseline -Dapp-runtime=none -Drenderer=opengl -Doptimize=ReleaseFast
           bash scripts/ghostty-compat-symlinks.sh
 
       - name: Build cmux-linux (terminal-first)
         run: |
           cd cmux-linux
-          zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast -Dno-webkit=true
+          zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dno-webkit=true
 
       - name: Build cmuxd
         run: |
           if [ -d cmuxd ]; then
-            cd cmuxd && zig build -Dtarget=${{ matrix.arch.zig }} -Doptimize=ReleaseFast
+            cd cmuxd && zig build -Dcpu=baseline -Doptimize=ReleaseFast
           fi
 
       - name: Assemble RPM package


### PR DESCRIPTION
## Summary

Supersedes the `-Dtarget=...` release-build approach from PR #272 with `-Dcpu=baseline`.

## Why

Release run `25082497926` showed that explicit `-Dtarget=x86_64-linux-gnu` makes the vendor library builds behave like cross-builds and stop finding distro system libraries via pkg-config/system paths:

- `unable to find dynamic system library 'secret-1'`
- `unable to find dynamic system library 'gio-2.0'`
- `unable to find dynamic system library 'gobject-2.0'`
- `unable to find dynamic system library 'glib-2.0'`

We still need to avoid native runner CPU features in release artifacts because the Fedora VM smoke test previously showed `Illegal instruction` for both `cmux --version` and `cmux --help`.

`-Dcpu=baseline` is the narrower fix: it keeps native OS/ABI and system library resolution, while preventing Zig from emitting instructions for the builder CPU.

## Changes

- Replace release workflow `-Dtarget=${{ matrix.arch.zig }}` with `-Dcpu=baseline`.
- Remove the now-unneeded release matrix `zig` target fields.

The stricter distro VM smoke test and Rocky sed delimiter fix remain from #272.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml"); puts "release-linux.yml parses"'`
- `nix-instantiate --parse nix/tests-distro.nix`
- `git diff --check`

Release run `25082497926` was cancelled after the `-Dtarget` vendor-link failure was confirmed.
