### PR TITLE
[codex] Document Linux graphical QA machine plan

### DIFF
--- a/docs/distro-testing-readiness-plan.md
+++ b/docs/distro-testing-readiness-plan.md
@@ -9,6 +9,7 @@ Use it with:
 - `docs/program-status.md`
 - `docs/linux-program-plan.md`
 - `docs/linux-packaging-cd-plan.md`
+- `docs/linux-graphical-qa-machine-plan.md`
 - `docs/linux-parity-matrix.md`
 - `docs/linux-validation-checklist.md`
 - `docs/flakehub-qa-ownership-notes.md`
@@ -108,6 +109,33 @@ What is still missing:
 - broader command coverage on Linux
 - browser automation beyond the current limited socket surface
 - direct automation for WebAuthn, notifications, and lock integration
+
+### 4. Graphical human QA
+
+Current sources:
+
+- `docs/linux-graphical-qa-machine-plan.md`
+- `docs/linux-qa-intake.md`
+- `docs/linux-validation-checklist.md`
+
+Current decision:
+
+- physical standard installs and normal user-managed VMs are the source of truth
+  for public graphical QA
+- `honey` KVM/QEMU remains useful for package proof and private lab work
+- NixOS desktop VM/QCOW surfaces can support internal demos and future visual
+  automation, but they do not yet replace distro-specific graphical testing
+
+Current machine-pool recommendation:
+
+- Ubuntu 24.04 GNOME and Fedora 42 GNOME for Tier A broad-feature proof
+- Fedora 42 KDE Plasma as the first DE-variance target
+- Debian 12 GNOME first, with Xfce optional later
+- Rocky 10.1 GNOME for terminal-first proof
+- CachyOS KDE Plasma as the primary Arch-family rolling target
+- Omarchy Hyprland as exploratory Arch/tiling coverage only
+- Linux Mint Cinnamon as the first Ubuntu-family community target
+- NixOS GNOME/Sway/Hyprland for internal lab and early Nix reports
 
 ## Required Readiness Moves
 

--- a/docs/linear-qa-shard-punchlist.md
+++ b/docs/linear-qa-shard-punchlist.md
@@ -8,6 +8,7 @@ work assignments without re-deriving scope from the codebase.
 
 Use it with:
 
+- [linux-graphical-qa-machine-plan.md](/Users/jess/git/cmux/docs/linux-graphical-qa-machine-plan.md:1)
 - [program-review-2026-04-14.md](/Users/jess/git/cmux/docs/program-review-2026-04-14.md:1)
 - [distro-testing-readiness-plan.md](/Users/jess/git/cmux/docs/distro-testing-readiness-plan.md:1)
 - [linux-work-week-2026-04-14.md](/Users/jess/git/cmux/docs/linux-work-week-2026-04-14.md:1)
@@ -300,6 +301,35 @@ Preferred evidence:
 
 These shards are for recruiting careful Linux QA users without overstating
 support. They should produce evidence, not broad support promises.
+
+### QA-MACH-001 Physical/User-VM QA Machine Pool
+
+- Type: QA infrastructure
+- Priority: `P0`
+- Goal: provision a concurrent pool of physical installs or normal user-managed
+  VMs for graphical Linux QA
+- Decision:
+  - public graphical QA truth comes from physical installs or ordinary user VMs
+  - `honey` KVM/QEMU remains the package-proof and private lab lane
+  - NixOS desktop VMs are useful for internal demos, but not a substitute for
+    distro-specific graphical claims
+- First targets:
+  - Ubuntu 24.04 LTS, GNOME Wayland
+  - Fedora 42 Workstation, GNOME Wayland
+  - Fedora 42 KDE Plasma Desktop
+  - Debian 12 GNOME; Xfce optional later
+  - Rocky 10.1 Workstation/GNOME
+  - CachyOS KDE Plasma
+  - Omarchy Hyprland as exploratory only
+  - Linux Mint Cinnamon
+  - NixOS GNOME/Sway/Hyprland for lab and early Nix reports
+- References:
+  - [linux-graphical-qa-machine-plan.md](/Users/jess/git/cmux/docs/linux-graphical-qa-machine-plan.md:1)
+  - [linux-qa-intake.md](/Users/jess/git/cmux/docs/linux-qa-intake.md:1)
+- Exit criteria:
+  - each P0 machine has one current install note, artifact under test, and owner
+  - P1 machines are clearly marked compatibility-discovery only
+  - no public support claim depends only on internal NixOS/QEMU lab proof
 
 ### QA-CAD-001 Linux QA Cadence
 

--- a/docs/linux-graphical-qa-machine-plan.md
+++ b/docs/linux-graphical-qa-machine-plan.md
@@ -1,0 +1,112 @@
+# Linux Graphical QA Machine Plan
+
+This note records the current decision for human graphical QA, physical target
+machines, and how the existing KVM/QEMU infrastructure should be used.
+
+Use it with:
+
+- `docs/linux-qa-intake.md`
+- `docs/linux-validation-checklist.md`
+- `docs/distro-testing-readiness-plan.md`
+- `docs/linear-qa-shard-punchlist.md`
+
+## Decision
+
+Public Linux QA should use physical standard installs or normal user-managed VMs
+as the source of truth for graphical behavior.
+
+The existing `honey` KVM/QEMU infrastructure remains valuable, but it should be
+treated as a private lab substrate until the repo has a distro-specific
+graphical harness that launches the release package inside the target desktop
+session.
+
+Current interpretation:
+
+- release KVM tests prove package install, runtime dependencies, and binary
+  launch behavior
+- Linux socket tests prove control-plane behavior under Xvfb / no-surface mode
+- NixOS desktop VMs prove that a reusable graphical lab substrate exists
+- physical installs and ordinary VMs prove real distro desktop integration
+- no Linux visual-regression or accessibility gate should be claimed until a
+  dedicated harness exists
+
+## Existing Local Lab Substrate
+
+The repo already has useful graphical lab pieces:
+
+- `nix run .#wayland-gnome`
+- `nix run .#wayland-sway`
+- `nix run .#wayland-hyprland`
+- `nix build .#qcow2-gnome`
+- `nix build .#qcow2-sway`
+- `nix build .#qcow2-hyprland`
+- `.github/workflows/release-qcow2.yml`
+
+Those are NixOS desktop variants. They are useful for internal demos,
+compositor smoke, screenshots, and future visual automation. They are not
+currently a substitute for Ubuntu, Fedora, Debian, Rocky, Arch, or Mint QA.
+
+Known limitation: `nix/tests.nix` still uses `foot` for the graphical GNOME
+window check, so it verifies compositor and screenshot plumbing more than cmux
+UI behavior.
+
+## Physical / User-VM QA Matrix
+
+| Priority | Distro | Desktop/session | Support posture | Why this target exists |
+|---|---|---|---|---|
+| P0 | Ubuntu 24.04 LTS | Ubuntu Desktop / GNOME Wayland | Tier A broad-feature | Mainstream LTS deb-family desktop and first public QA ask |
+| P0 | Fedora 42 | Workstation / GNOME Wayland | Tier A broad-feature | Modern GNOME, Wayland, GTK, WebKitGTK, portal, notification, and Secret Service target |
+| P0 | Fedora 42 | KDE Plasma Desktop | Tier A adjunct | Official Fedora KDE edition; catches KDE portal/session/notification differences |
+| P0 | Debian 12 | GNOME first; Xfce optional | Tier B baseline | Stable deb-family install/runtime baseline; browser/WebAuthn status must be recorded explicitly |
+| P0 | Rocky 10.1 | Workstation / GNOME; KDE optional | Tier C terminal-first | Enterprise/RHEL-family constrained target; no-WebKit RPM path stays terminal-first |
+| P1 | Arch rolling | CachyOS KDE Plasma | Community early report | Opinionated Arch-family rolling desktop with a known KDE default path |
+| P1 | Arch rolling | Omarchy Hyprland | Exploratory early report | Opinionated Arch + Hyprland developer desktop; good Wayland/tiling stress target, not a baseline support target |
+| P1 | Linux Mint | Cinnamon | Community early report | Ubuntu-family mainstream desktop outside vanilla Ubuntu; good user-facing DE coverage |
+| P1 | NixOS | GNOME, Sway, or Hyprland | Internal lab plus early report | Matches repo VM surfaces and Nix user expectations; useful for reproducible lab work |
+
+If only one Arch-family machine is available, use CachyOS KDE Plasma first. Add
+Omarchy only when there is room for a tiling/Hyprland compatibility lane.
+
+If only one Mint-family machine is available, use Cinnamon first. Mint MATE and
+Xfce are useful later for lower-resource or traditional-panel coverage, but
+Cinnamon is the most representative first pass.
+
+## Manual QA Evidence Required
+
+Every physical or user-VM report should include:
+
+- distro, version, desktop/session, architecture, and GPU/session notes
+- exact cmux artifact filename or release tag
+- install command and install result
+- `cmux --version` output
+- terminal and split smoke result
+- socket/API smoke result
+- browser status where expected
+- notification status
+- WebAuthn/FIDO2 status where practical
+- lock/session status
+- screenshots or short video for UI defects
+
+## Promotion Rules
+
+Do not promote a distro or capability from a manual report alone unless the
+report includes enough evidence to reproduce the claim.
+
+Recommended interpretation:
+
+- one clean physical/user-VM pass can unblock early QA language
+- repeated clean passes across different machines can support stronger docs
+- package-install KVM proof is still required for release artifact confidence
+- visual regression and accessibility automation remain future gates
+
+## Source Notes
+
+The desktop choices above are based on official current surfaces:
+
+- Ubuntu official flavors: `https://ubuntu.com/desktop/flavors`
+- Fedora Workstation/KDE/spins listing: `https://www.fedoraproject.org/workstation/`
+- Debian live images: `https://www.debian.org/CD/live/index`
+- Rocky Linux 10 live images: `https://dl.rockylinux.org/pub/rocky/10/live/x86_64/`
+- Linux Mint edition guide: `https://linuxmint-installation-guide.readthedocs.io/en/latest/choose.html`
+- CachyOS desktop environments: `https://wiki.cachyos.org/installation/desktop_environments/`
+- Omarchy official site: `https://omarchy.org/`

--- a/docs/linux-qa-intake.md
+++ b/docs/linux-qa-intake.md
@@ -6,6 +6,7 @@ overstating support.
 Use it with:
 
 - `docs/distro-testing-readiness-plan.md`
+- `docs/linux-graphical-qa-machine-plan.md`
 - `docs/linux-validation-checklist.md`
 - `docs/release/linux-install.md`
 - `docs/linear-qa-shard-punchlist.md`
@@ -15,6 +16,12 @@ Use it with:
 QA reports are evidence, not support promises. Every report should preserve the
 current distro tier and the exact artifact under test.
 
+Graphical QA should use physical standard installs or normal user-managed VMs as
+the source of truth for public claims. The existing `honey` KVM/QEMU and NixOS
+desktop VM surfaces are useful private lab infrastructure, but they are not yet
+a distro-specific graphical QA replacement for Ubuntu, Fedora, Debian, Rocky,
+Arch, or Mint installs.
+
 ## Distro Tiers
 
 | Tier | Distros | QA ask |
@@ -23,6 +30,21 @@ current distro tier and the exact artifact under test.
 | Tier B baseline | Debian 12 | package/runtime baseline plus explicit browser and WebAuthn status |
 | Tier C terminal-first | Rocky 10 | terminal, splits, focus, socket/API, and clear browser-unavailable behavior |
 | Community early reports | Arch, Mint, NixOS | compatibility discovery; no broad support claim until repeated evidence exists |
+
+## First Machine Targets
+
+Use the full matrix in `docs/linux-graphical-qa-machine-plan.md` for provisioning
+details. The first physical/user-VM pool should prioritize:
+
+- Ubuntu 24.04 LTS, default GNOME Wayland
+- Fedora 42 Workstation, GNOME Wayland
+- Fedora 42 KDE Plasma Desktop as the first DE-variance target
+- Debian 12 GNOME first, with Xfce optional later
+- Rocky 10.1 Workstation/GNOME for terminal-first proof
+- CachyOS KDE Plasma as the first Arch-family rolling target
+- Omarchy Hyprland only as an exploratory Arch/tiling target
+- Linux Mint Cinnamon as the first Ubuntu-family community target
+- NixOS GNOME/Sway/Hyprland as an internal lab and early Nix report target
 
 ## Cadence
 


### PR DESCRIPTION
## Summary
- record the decision that public graphical Linux QA should use physical installs or ordinary user-managed VMs
- add a first-pass distro/DE machine pool for Ubuntu, Fedora, Debian, Rocky, Arch-family, Mint, and NixOS targets
- thread the decision into the QA intake, distro readiness, and shard punchlist docs

## Validation
- git diff --check

## Linear
- TIN-732