### PR TITLE
[codex] Promote green Linux socket candidates

### DIFF
--- a/docs/distro-testing-readiness-plan.md
+++ b/docs/distro-testing-readiness-plan.md
@@ -100,8 +100,8 @@ Current sources:
 What exists now:
 
 - 123 `tests_v2` test files on disk
-- 18 stable Linux baseline tests
-- 11 gated phase-1 candidate tests running as non-fatal observations
+- 28 stable Linux baseline tests
+- 1 gated phase-1 candidate test running as a non-fatal observation
 
 What is still missing:
 
@@ -153,9 +153,9 @@ Current baseline is intentionally conservative.
 
 Near-term target:
 
-- promote green phase-1 candidates into baseline
+- keep the newly promoted baseline green
 - keep the baseline small enough to trust
-- move Linux socket coverage materially above the current 18-test stable floor
+- move Linux socket coverage materially above the current 28-test stable floor
 
 Follow-on target:
 

--- a/docs/program-status.md
+++ b/docs/program-status.md
@@ -162,12 +162,12 @@ Current gap:
 Current `scripts/run-socket-tests.sh` coverage includes:
 
 - 123 `tests_v2` test files on disk
-- 18 baseline tests that fail the Linux socket job when red
-- 11 phase-1 candidate tests that run as non-fatal observations
+- 28 baseline tests that fail the Linux socket job when red
+- 1 phase-1 candidate test that runs as a non-fatal observation
 
-Recent CI made the baseline contract useful but exposed one active baseline
-failure: `test_surface_action_close_variants`. That should be fixed or
-explicitly reclassified before promoting more candidate tests.
+Recent CI made the baseline contract useful enough to promote the repeated-green
+phase-1 candidates. `test_sprint_b_core_parity` remains observational because
+it still represents the known Linux remote-workspace parity gap.
 
 ### Merge governance
 

--- a/scripts/run-socket-tests.sh
+++ b/scripts/run-socket-tests.sh
@@ -114,17 +114,21 @@ fi
 echo "Socket ready"
 
 # ── Baseline allowlist ──────────────────────────────────────────────
-# The 18 tests known to pass on cmux-linux today. A failure in any of
+# The 28 tests known to pass on cmux-linux today. A failure in any of
 # these fails the job.
 BASELINE=(
+  test_browser_open_split_reuse_policy
   test_close_surface_selection
   test_close_workspace_selection
   test_focus_notification_dismiss
   test_nested_split_no_detach_during_update
   test_notification_socket_api
+  test_notification_create_for_target
+  test_pane_resize
   test_pane_break_swap_preserve_focus
   test_pane_operations
   test_signals_auto
+  test_surface_report_tty
   test_surface_split_tree
   test_system_api
   test_surface_action_rename
@@ -135,6 +139,12 @@ BASELINE=(
   test_workspace_lifecycle
   test_workspace_navigation
   test_workspace_reorder
+  test_workspace_create_background_starts_terminal
+  test_workspace_create_initial_env
+  test_workspace_action
+  test_auth_login
+  test_system_tree
+  test_app_simulate_active
 )
 
 # ── Phase 1 candidate allowlist (gated) ─────────────────────────────
@@ -142,18 +152,8 @@ BASELINE=(
 # when CMUX_TEST_PHASE1=1. Candidate failures are reported but do not
 # fail the job — see header comment for promotion workflow.
 CANDIDATES_PHASE1=(
-  test_browser_open_split_reuse_policy
-  test_workspace_create_background_starts_terminal
-  test_workspace_create_initial_env
-  # Remaining Sprint A / Sprint B gaps observed on run 24743528001.
-  test_workspace_action
-  test_auth_login
-  test_system_tree
-  test_notification_create_for_target
-  test_app_simulate_active
-  test_surface_report_tty
-  test_pane_resize
-  # Sprint B handlers (PR #230):
+  # Known Linux remote-workspace parity gap. Keep observational until the
+  # remote workspace semantics exist on cmux-linux.
   test_sprint_b_core_parity
 )
 


### PR DESCRIPTION
## Summary
- move the ten repeatedly green phase-1 Linux socket tests into the hard baseline
- leave `test_sprint_b_core_parity` as the only non-fatal candidate for the known Linux remote-workspace parity gap
- update program/readiness docs from 18 baseline + 11 candidates to 28 baseline + 1 candidate

## Validation
- `bash -n scripts/run-socket-tests.sh`
- `git diff --check`

## Linear
- TIN-183