### PR TITLE
[codex] Handle Linux version flags before GTK init

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build cmux-linux
         run: |
           cd cmux-linux
-          zig build -Dcpu=baseline -Doptimize=ReleaseFast
+          zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dversion="${{ steps.version.outputs.version }}"
 
       - name: Build cmuxd
         run: |
@@ -290,7 +290,7 @@ jobs:
       - name: Build cmux-linux
         run: |
           cd cmux-linux
-          zig build -Dcpu=baseline -Doptimize=ReleaseFast
+          zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dversion="${{ steps.version.outputs.version }}"
 
       - name: Build cmuxd
         run: |
@@ -438,7 +438,7 @@ jobs:
       - name: Build cmux-linux (terminal-first)
         run: |
           cd cmux-linux
-          zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dno-webkit=true
+          zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dno-webkit=true -Dversion="${{ steps.version.outputs.version }}"
 
       - name: Build cmuxd
         run: |

--- a/cmux-linux/build.zig
+++ b/cmux-linux/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const headless = b.option(bool, "headless", "Build terminal-only mode (no GTK4/GUI)") orelse false;
     const no_webkit = b.option(bool, "no-webkit", "Build without WebKitGTK (no browser panel). Use on RHEL/Rocky where WebKitGTK is unavailable.") orelse false;
+    const version = b.option([]const u8, "version", "cmux version string for --version output") orelse "dev";
 
     const root_source = if (headless)
         b.path("src/main_headless.zig")
@@ -17,6 +18,7 @@ pub fn build(b: *std.Build) void {
     // Build options for conditional compilation (WebKitGTK availability)
     const build_options = b.addOptions();
     build_options.addOption(bool, "enable_webkit", enable_webkit);
+    build_options.addOption([]const u8, "version", version);
 
     const root_module = b.createModule(.{
         .root_source_file = root_source,

--- a/cmux-linux/src/main.zig
+++ b/cmux-linux/src/main.zig
@@ -4,6 +4,7 @@
 /// libghostty, and runs the main event loop.
 const std = @import("std");
 const posix = std.posix;
+const build_options = @import("build_options");
 const c = @import("c_api.zig");
 const app_mod = @import("app.zig");
 const window = @import("window.zig");
@@ -85,7 +86,43 @@ fn tickCallback(_: ?*anyopaque) callconv(.c) c.gtk.gboolean {
     return c.gtk.G_SOURCE_REMOVE;
 }
 
+fn printUsage(writer: anytype) !void {
+    try writer.print(
+        \\cmux {s}
+        \\
+        \\Usage:
+        \\  cmux [--version]
+        \\  cmux [--help]
+        \\
+        \\Options:
+        \\  -h, --help       Show this help.
+        \\  -V, --version    Print the cmux version.
+        \\
+    , .{build_options.version});
+}
+
+fn handleEarlyCliArgs() !bool {
+    var args = std.process.args();
+    _ = args.next();
+
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-V")) {
+            try std.io.getStdOut().writer().print("cmux {s}\n", .{build_options.version});
+            return true;
+        }
+
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            try printUsage(std.io.getStdOut().writer());
+            return true;
+        }
+    }
+
+    return false;
+}
+
 pub fn main() !void {
+    if (try handleEarlyCliArgs()) return;
+
     // Initialize libghostty
     _ = c.ghostty.ghostty_init(0, null);
 

--- a/cmux-linux/src/main.zig
+++ b/cmux-linux/src/main.zig
@@ -86,8 +86,19 @@ fn tickCallback(_: ?*anyopaque) callconv(.c) c.gtk.gboolean {
     return c.gtk.G_SOURCE_REMOVE;
 }
 
-fn printUsage(writer: anytype) !void {
-    try writer.print(
+fn printVersion() !void {
+    var stdout_buf: [128]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("cmux {s}\n", .{build_options.version});
+    try stdout.flush();
+}
+
+fn printUsage() !void {
+    var stdout_buf: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer.interface;
+    try stdout.print(
         \\cmux {s}
         \\
         \\Usage:
@@ -99,6 +110,7 @@ fn printUsage(writer: anytype) !void {
         \\  -V, --version    Print the cmux version.
         \\
     , .{build_options.version});
+    try stdout.flush();
 }
 
 fn handleEarlyCliArgs() !bool {
@@ -107,12 +119,12 @@ fn handleEarlyCliArgs() !bool {
 
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-V")) {
-            try std.io.getStdOut().writer().print("cmux {s}\n", .{build_options.version});
+            try printVersion();
             return true;
         }
 
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
-            try printUsage(std.io.getStdOut().writer());
+            try printUsage();
             return true;
         }
     }

--- a/cmux-linux/src/main_headless.zig
+++ b/cmux-linux/src/main_headless.zig
@@ -5,7 +5,6 @@
 ///
 /// Build with: zig build -Dheadless=true
 /// Binary: cmux-term
-
 const std = @import("std");
 const config = @import("config.zig");
 
@@ -25,8 +24,11 @@ pub fn main() !void {
     // TODO: Create PTY and run default shell
     // TODO: Forward stdin/stdout to the PTY
 
-    const stdout = std.io.getStdOut().writer();
+    var stdout_buf: [512]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer.interface;
     try stdout.print("cmux-term: headless terminal mode\n", .{});
     try stdout.print("Socket control: $XDG_RUNTIME_DIR/cmux.sock\n", .{});
     try stdout.print("Config: ~/.config/cmux/cmux.json\n", .{});
+    try stdout.flush();
 }


### PR DESCRIPTION
## Summary
- handle `cmux --version`, `cmux -V`, `cmux --help`, and `cmux -h` before libghostty/GTK initialization
- add a `cmux-linux` build option for the version string, defaulting to `dev`
- pass the release tag version into Linux DEB/RPM/tarball builds

## Why
The fresh `release-linux.yml` proof run built and signed all Linux packages, but the exact-artifact Fedora 42 KVM validation failed after package install because `cmux --version || cmux --help` tried to initialize GTK without a display:

- run: https://github.com/Jesssullivan/cmux/actions/runs/25085742918
- failed job: `Validate Linux packages in distro VMs`
- failure: `Gtk-WARNING **: Failed to open display`, then `RequestedAssertionFailed` for `cmux --version 2>&1 || cmux --help 2>&1`

This preserves the KVM test contract and the documented QA install command instead of weakening either one.

## Validation
- `zig fmt cmux-linux/build.zig cmux-linux/src/main.zig`
- `zig fmt --check cmux-linux/build.zig cmux-linux/src/main.zig`
- `git diff --check`

Not run locally: Linux package/KVM validation; that remains CI/self-hosted runner evidence per repo policy.

Linear: TIN-614, TIN-184
