### PR TITLE
[codex] Treat Debian package validation as diagnostic

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -628,11 +628,12 @@ jobs:
       - name: Rocky 10 package test
         run: bash scripts/run-distro-package-check.sh distro-rocky10
 
-      - name: Debian 12 package test
-        run: bash scripts/run-distro-package-check.sh distro-debian12
-
       - name: Ubuntu 24.04 package test
         run: bash scripts/run-distro-package-check.sh distro-ubuntu2404
+
+      - name: Debian 12 package test (baseline diagnostic)
+        continue-on-error: true
+        run: bash scripts/run-distro-package-check.sh distro-debian12
 
       - name: Upload distro validation logs
         if: always()

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -170,13 +170,14 @@ jobs:
         if: inputs.distro == 'rocky10'
         run: bash scripts/run-distro-package-check.sh distro-rocky10
 
-      - name: Debian 12 package test
-        if: inputs.distro == 'all' || inputs.distro == 'debian12' || inputs.distro == ''
-        run: bash scripts/run-distro-package-check.sh distro-debian12
-
       - name: Ubuntu 24.04 package test
         if: inputs.distro == 'all' || inputs.distro == 'ubuntu2404' || inputs.distro == ''
         run: bash scripts/run-distro-package-check.sh distro-ubuntu2404
+
+      - name: Debian 12 package test (baseline diagnostic)
+        if: inputs.distro == 'all' || inputs.distro == 'debian12' || inputs.distro == ''
+        continue-on-error: ${{ inputs.distro != 'debian12' }}
+        run: bash scripts/run-distro-package-check.sh distro-debian12
 
       - name: Upload test logs
         if: always()

--- a/docs/distro-testing-readiness-plan.md
+++ b/docs/distro-testing-readiness-plan.md
@@ -16,15 +16,21 @@ Use it with:
 
 ## Snapshot
 
-As of 2026-04-25:
+As of 2026-04-29:
 
 - hosted Linux CI is already green on `Ubuntu 24.04`, `Fedora 42`, `Rocky 10`,
   `Debian 12` baseline, and `Arch`
 - tagged Linux releases already build signed multi-arch `DEB`, `RPM`, and
   tarball assets
 - release-gated KVM package validation now executes real `.sandboxed` VM tests
-  for `Ubuntu 24.04`, `Debian 12`, `Fedora 42`, and `Rocky 9` as the current
-  RPM-path proxy
+  for `Ubuntu 24.04`, `Fedora 42`, and the dedicated `Rocky 10`
+  terminal-first RPM path before upload
+- `Debian 12` remains a baseline/no-WebKit lane; the current broad-feature
+  Ubuntu-family `DEB` is diagnostic there until a separate Debian baseline
+  artifact or backports policy is chosen
+- release run `25087301829` proved the exact signed Fedora 42 RPM and Rocky 10
+  terminal-first RPM in KVM; the upload was blocked by the Debian diagnostic
+  mismatch before Ubuntu could run
 - `numtide/nix-vm-test#172` merged on 2026-04-22 with `Fedora 42` and
   `Rocky 10.1` image support, so upstream image availability is no longer the
   blocker
@@ -38,9 +44,9 @@ As of 2026-04-25:
 | Target | Current build proof | Current KVM / QEMU proof | Current release gating | Current direct QA | Target posture |
 |---|---|---|---|---|---|
 | `Ubuntu 24.04` | hosted CI green | yes | yes | still needs one recorded broad-feature pass | Tier A broad-feature |
-| `Fedora 42` | hosted CI green, RPM builds on Fedora 42 | yes; using upstream `nix-vm-test` image support | yes | still needs one recorded broad-feature pass | Tier A broad-feature |
-| `Debian 12` | hosted CI green with baseline `-Dno-webkit` lane | yes | yes | still needs one explicit browser/WebAuthn status record | Tier B baseline |
-| `Rocky 10` | hosted CI green, constrained build posture is real | upstream `Rocky 10.1` image support exists; branch-wired through a dedicated `rpmRocky` asset when the manifest provides it; checked-in manifest still defaults to proxy-only | next tagged release should gate it | still needs one terminal-first proof pass | Tier C constrained |
+| `Fedora 42` | hosted CI green, RPM builds on Fedora 42 | yes; first exact-artifact proof recorded in run `25087301829` | yes | still needs one recorded broad-feature pass | Tier A broad-feature |
+| `Debian 12` | hosted CI green with baseline `-Dno-webkit` lane | baseline automation exists; broad-feature release `DEB` is diagnostic until artifact taxonomy is fixed | diagnostic only | still needs one explicit browser/WebAuthn status record | Tier B baseline |
+| `Rocky 10` | hosted CI green, constrained build posture is real | yes; first exact-artifact terminal-first proof recorded in run `25087301829` | yes, when `rpmRocky` exists | still needs one direct terminal-first report | Tier C constrained |
 | `arm64` Linux artifacts | multi-arch release builds exist | not yet | not yet | none | follow-on after x86_64 proof |
 
 ## Automation Surfaces
@@ -75,11 +81,11 @@ Current sources:
 What exists now:
 
 - `Ubuntu 24.04` `DEB` install validation
-- `Debian 12` `DEB` install validation
 - `Fedora 42` `RPM` install validation
-- `Rocky 9` `RPM` proxy validation
-- branch wiring for `Rocky 10` terminal-first validation through a dedicated
-  `rpmRocky` asset
+- `Rocky 10` terminal-first validation through a dedicated `rpmRocky` asset
+- `Debian 12` diagnostic validation of the current `DEB`, with failure treated
+  as evidence for the pending baseline artifact decision rather than a
+  broad-feature release blocker
 - current checks resolve to `.sandboxed` VM runs rather than driver-only
   derivations
 - release-time validation of the exact x86_64 `DEB` and `RPM` assets before
@@ -87,7 +93,8 @@ What exists now:
 
 What is still missing:
 
-- first green `Rocky 10` VM install proof
+- a separate Debian 12 baseline/no-WebKit package artifact, or an explicit
+  Debian backports policy for the broad-feature `DEB`
 - arm64 KVM validation
 
 ### 3. Socket and control-plane automation
@@ -145,15 +152,18 @@ This is the current release-critical gap.
 
 Required outcome:
 
-1. keep `Ubuntu 24.04` and `Debian 12` green
+1. keep `Ubuntu 24.04` green for the broad-feature `DEB`
 2. keep `Fedora 42` KVM proof green and visible in CI
-3. replace the `Rocky 9` proxy with real `Rocky 10` terminal-first proof
+3. keep real `Rocky 10` terminal-first proof green when `rpmRocky` exists
+4. decide and implement the Debian 12 baseline artifact path
 
 Recommended owned path:
 
 1. keep `Rocky 10` only when the artifact under test matches the constrained
    distro promise
-2. keep the former `Jesssullivan/nix-vm-test` carry reason visible in
+2. treat Debian 12 broad-feature `DEB` results as diagnostic until a baseline
+   artifact exists
+3. keep the former `Jesssullivan/nix-vm-test` carry reason visible in
    `Jesssullivan/cmux` issues, Tinyland Linear, and
    `docs/flakehub-qa-ownership-notes.md` as historical context
 
@@ -297,11 +307,12 @@ Until then:
 
 ## Ordered Next Actions
 
-1. get first green CI evidence for the wired `Fedora 42` QEMU lane
-2. record the first green `Rocky 10` terminal-first run and then retire the
-   `Rocky 9` proxy
-3. record one direct QA pass for `Ubuntu 24.04`, `Fedora 42`, `Debian 12`, and
+1. rerun release-gated proof after the Debian diagnostic posture change so
+   Ubuntu/Fedora/Rocky exact-artifact gates can upload signed assets
+2. record one direct QA pass for `Ubuntu 24.04`, `Fedora 42`, `Debian 12`, and
    `Rocky 10`
+3. decide whether Debian 12 gets a separate no-WebKit `DEB` or a documented
+   backports-based install path
 4. promote Linux socket-test candidates into baseline only after green proof
 5. keep `WebAuthn`, socket parity, and browser claims honest in the matrix
 6. defer `lmux` renaming work unless the revisit triggers become real

--- a/docs/linux-packaging-cd-plan.md
+++ b/docs/linux-packaging-cd-plan.md
@@ -13,15 +13,18 @@ Use it with:
 
 ## Current State
 
-As of 2026-04-25:
+As of 2026-04-29:
 
 - hosted Linux CI is green across `Ubuntu 24.04`, `Fedora 42`, `Rocky 10`,
   `Debian 12` baseline, `Arch`, and the vendor-library lane
 - self-hosted distro package-install tests now execute real `.sandboxed` VM
-  runs for `Ubuntu 24.04`, `Debian 12`, `Fedora 42`, and `Rocky 9` as an
-  RPM-path proxy
+  runs for `Ubuntu 24.04`, `Fedora 42`, and dedicated `Rocky 10`
+  terminal-first release artifacts
 - the release workflow now builds a separate Rocky 10 terminal-first RPM and
   wires it into the release-gated VM validator
+- release run `25087301829` proved the exact signed Fedora 42 and Rocky 10 RPMs
+  in KVM; release upload was blocked by the Debian 12 broad-feature `DEB`
+  diagnostic mismatch before Ubuntu could run
 - Linux release automation builds:
   - `DEB`
   - `RPM`
@@ -98,10 +101,11 @@ What they do today:
 - upload Linux assets to the matching GitHub Release
 - upload macOS assets separately through the fork release workflow
 
-Current limit:
-- Linux release gating currently covers `Ubuntu 24.04`, `Debian 12`,
-  `Fedora 42`, `Rocky 10`, and `Rocky 9` as the temporary proxy; `arm64`
-  remains outside the gated VM matrix
+Current limits:
+- Linux release gating currently covers `Ubuntu 24.04`, `Fedora 42`, and
+  `Rocky 10`; `arm64` remains outside the gated VM matrix
+- `Debian 12` is diagnostic in release workflows until a Debian baseline
+  no-WebKit artifact or explicit backports policy exists
 
 ### 4. Flatpak
 
@@ -135,7 +139,14 @@ desktops:
 This is the artifact lane that proves package/runtime viability without implying
 full browser parity:
 
-- Debian 12 `DEB` install validation
+- Debian 12 no-WebKit `DEB` install validation
+
+Current interpretation:
+- the hosted Debian 12 build lane already proves the source can build
+  `-Dno-webkit=true`
+- the current release `DEB` is a broad-feature Ubuntu-family artifact and
+  should not be treated as Debian baseline proof until dependency policy is
+  resolved
 
 ### Constrained artifact
 
@@ -177,9 +188,9 @@ Current read:
 - the shipped Linux binary does not currently link `libsecret` or `libnotify`,
   so those should not be declared as package requirements just because helper
   libraries exist elsewhere in the tree
-- this creates a real Debian 12 tension: a truthful broad-feature `DEB` may no
-  longer fit the current Debian baseline install lane without either backports
-  or a separate no-WebKit artifact
+- this creates a real Debian 12 tension: the truthful broad-feature `DEB` does
+  not currently fit the Debian baseline install lane without either backports or
+  a separate no-WebKit artifact
 
 ### 3. Release tests are pinned to a checked-in artifact manifest
 

--- a/docs/release/linux-install.md
+++ b/docs/release/linux-install.md
@@ -18,7 +18,7 @@ promise.
 |---|---|---|
 | Ubuntu 24.04 | `DEB` | broad-feature target |
 | Fedora 42 | Fedora `RPM` | broad-feature target |
-| Debian 12 | `DEB` | package/runtime baseline; browser and WebAuthn status must be recorded explicitly |
+| Debian 12 | baseline/no-WebKit `DEB` pending | package/runtime baseline; current broad-feature `DEB` is diagnostic only |
 | Rocky 10 | Rocky `RPM` | terminal-first target; uses the no-WebKit package path |
 | Arch, Mint, NixOS | source/package-manager follow-up | early QA target, not a broad support claim yet |
 
@@ -58,9 +58,9 @@ For RPM verification:
 sudo rpm --import https://github.com/Jesssullivan/cmux/raw/main/docs/release/cmux-release-signing-key.asc
 ```
 
-## Verify And Install A DEB
+## Verify And Install An Ubuntu DEB
 
-Use this path for Ubuntu 24.04 and Debian 12.
+Use this path for Ubuntu 24.04.
 
 ```bash
 gpg --verify cmux_<version>_amd64.deb.asc cmux_<version>_amd64.deb
@@ -69,8 +69,9 @@ sudo apt-get install ./cmux_<version>_amd64.deb
 cmux --version
 ```
 
-On Debian 12, record browser and WebAuthn status explicitly. A successful
-package install is baseline proof, not a full-feature claim.
+Debian 12 is tracked as a baseline/no-WebKit target. Until a distinct Debian
+baseline artifact exists, attempts to install the broad-feature Ubuntu-family
+`DEB` on Debian should be recorded as diagnostic results, not support proof.
 
 ## Verify And Install A Fedora RPM
 


### PR DESCRIPTION
## Summary

- gate Linux release upload on Fedora 42, Rocky 10, and Ubuntu 24.04 exact-artifact validation before running Debian
- keep Debian 12 package validation as a diagnostic baseline/no-WebKit signal until a Debian-specific artifact or backports policy exists
- update Linux packaging/install docs to stop treating the broad-feature Ubuntu-family DEB as Debian baseline proof

## Validation

- ruby YAML parse for `.github/workflows/release-linux.yml` and `.github/workflows/test-distro.yml`

## Tracker links

- TIN-614: signed artifact proof stays in progress until a rerun uploads fresh assets
- TIN-745: Debian 12 baseline/no-WebKit DEB artifact decision
- TIN-184: first Fedora/Rocky KVM proof recorded and closed
- Jesssullivan/cmux#187: remains open until successful release upload publishes the Rocky RPM and proxy language is retired

## Notes

Release run `25087301829` already proved the exact signed Fedora 42 RPM and Rocky 10 terminal-first RPM in KVM. Its remaining failure was the Debian 12 broad-feature DEB mismatch; Ubuntu was skipped only because Debian previously ran first and failed hard.
