### PR TITLE
[codex] Add Ubuntu distro VM disk headroom

### DIFF
--- a/docs/distro-testing-readiness-plan.md
+++ b/docs/distro-testing-readiness-plan.md
@@ -29,8 +29,11 @@ As of 2026-04-29:
   Ubuntu-family `DEB` is diagnostic there until a separate Debian baseline
   artifact or backports policy is chosen
 - release run `25087301829` proved the exact signed Fedora 42 RPM and Rocky 10
-  terminal-first RPM in KVM; the upload was blocked by the Debian diagnostic
-  mismatch before Ubuntu could run
+  terminal-first RPM in KVM
+- release run `25088831284` built and signed all Linux artifacts, re-proved
+  Fedora 42 and Rocky 10 in KVM, then exposed an Ubuntu 24.04 cloud-image disk
+  headroom blocker before release upload; PR `#278` adds Ubuntu VM disk
+  expansion for that broad-feature `DEB` validation
 - `numtide/nix-vm-test#172` merged on 2026-04-22 with `Fedora 42` and
   `Rocky 10.1` image support, so upstream image availability is no longer the
   blocker
@@ -307,7 +310,7 @@ Until then:
 
 ## Ordered Next Actions
 
-1. rerun release-gated proof after the Debian diagnostic posture change so
+1. rerun release-gated proof after the Ubuntu VM disk-headroom change so
    Ubuntu/Fedora/Rocky exact-artifact gates can upload signed assets
 2. record one direct QA pass for `Ubuntu 24.04`, `Fedora 42`, `Debian 12`, and
    `Rocky 10`

--- a/docs/linux-packaging-cd-plan.md
+++ b/docs/linux-packaging-cd-plan.md
@@ -23,8 +23,11 @@ As of 2026-04-29:
 - the release workflow now builds a separate Rocky 10 terminal-first RPM and
   wires it into the release-gated VM validator
 - release run `25087301829` proved the exact signed Fedora 42 and Rocky 10 RPMs
-  in KVM; release upload was blocked by the Debian 12 broad-feature `DEB`
-  diagnostic mismatch before Ubuntu could run
+  in KVM
+- release run `25088831284` built and signed all Linux artifacts, re-proved
+  Fedora 42 and Rocky 10 in KVM, then failed before upload because the Ubuntu
+  24.04 cloud image ran out of disk while unpacking the broad-feature `DEB`
+  dependency closure; PR `#278` adds Ubuntu VM disk expansion for that gate
 - Linux release automation builds:
   - `DEB`
   - `RPM`

--- a/nix/tests-distro.nix
+++ b/nix/tests-distro.nix
@@ -274,6 +274,10 @@
   # ── Test: Ubuntu 24.04 DEB install ───────────────────────────────
   distro-ubuntu2404 =
     (nvt.ubuntu."24_04" {
+      # The broad-feature DEB pulls in the GTK/WebKit desktop dependency
+      # closure. Ubuntu cloud images are too small for that unpack step unless
+      # the guest root disk is expanded before boot.
+      diskSize = "+8G";
       sharedDirs = {
         pkg = {
           source = "${cmuxDebDir}";


### PR DESCRIPTION
## Summary

- expand the Ubuntu 24.04 nix-vm-test guest root disk before package validation
- document that the headroom is needed for the broad-feature GTK/WebKit dependency closure

## Root cause

The fresh release proof built and signed all Linux artifacts and passed Fedora 42 plus Rocky 10 KVM validation, but Ubuntu 24.04 failed while unpacking the broad-feature DEB dependency closure because the default cloud image ran out of disk space.

## Validation

- `nix-instantiate --parse nix/tests-distro.nix`
- `git diff --check`

The real KVM package install remains CI-only and should run on the self-hosted runner for this PR.
